### PR TITLE
Support mini build

### DIFF
--- a/mini.Dockerfile
+++ b/mini.Dockerfile
@@ -1,5 +1,9 @@
 # vi: filetype=dockerfile
 
 FROM monobase:latest
-
-COPY monobase /srv/r8/monobase
+ENV COG_VERSION=0.11.3
+ENV CUDA_VERSION=12.4
+ENV CUDNN_VERSION=9
+ENV PYTHON_VERSION=3.12
+ENV TORCH_VERSION=2.4.1
+RUN /opt/r8/monobase/build.sh --mini

--- a/script/mini.sh
+++ b/script/mini.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Build mini image for testing
+# Build mini image for local development
 
 set -euo pipefail
 

--- a/src/build.sh
+++ b/src/build.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Build monobase
+
+set -euo pipefail
+
+export PATH="$MONOBASE_PREFIX/bin:$PATH"
+
+MONOBASE_PYTHON='3.12'
+DONE_FILE='/opt/r8/monobase/.done'
+
+UV_URL='https://github.com/astral-sh/uv/releases/latest/download/uv-x86_64-unknown-linux-gnu.tar.gz'
+PGET_URL='https://github.com/replicate/pget/releases/latest/download/pget_Linux_x86_64'
+
+log() {
+    echo "$(date --iso-8601=seconds --utc) $*"
+}
+
+mkdir -p "$MONOBASE_PREFIX/bin"
+
+# Always install latest uv and pget first
+
+log "Installing uv..."
+curl -fsSL "$UV_URL" | tar -xz --strip-components=1 -C "$MONOBASE_PREFIX/bin"
+"$MONOBASE_PREFIX/bin/uv" --version
+
+log "Installing pget..."
+curl -fsSL -o "$MONOBASE_PREFIX/bin/pget-bin" "$PGET_URL"
+chmod +x "$MONOBASE_PREFIX/bin/pget-bin"
+"$MONOBASE_PREFIX/bin/pget-bin" version
+
+# PGET FUSE wrapper
+cp /opt/r8/monobase/pget "$MONOBASE_PREFIX/bin/pget"
+
+log "Running builder..."
+uv run --python "$MONOBASE_PYTHON" --with requests /opt/r8/monobase/build.py "$@"
+
+# Inside K8S
+# Write done file to signal pod ready
+# Sleep keep pod alive
+if [ -n "${KUBERNETES_SERVICE_HOST:-}" ]; then
+    touch "$DONE_FILE"
+    sleep 86400
+fi

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -4,46 +4,11 @@
 
 set -euo pipefail
 
-MONOBASE_PYTHON='3.12'
-DONE_FILE='/opt/r8/monobase/.done'
-
-UV_URL='https://github.com/astral-sh/uv/releases/latest/download/uv-x86_64-unknown-linux-gnu.tar.gz'
-PGET_URL='https://github.com/replicate/pget/releases/latest/download/pget_Linux_x86_64'
+export PATH="$MONOBASE_PREFIX/bin:$PATH"
 
 log() {
     echo "$(date --iso-8601=seconds --utc) $*"
 }
-
-builder() {
-    mkdir -p "$MONOBASE_PREFIX/bin"
-
-    # Always install latest uv and pget first
-
-    log "Installing uv..."
-    curl -fsSL "$UV_URL" | tar -xz --strip-components=1 -C "$MONOBASE_PREFIX/bin"
-    "$MONOBASE_PREFIX/bin/uv" --version
-
-    log "Installing pget..."
-    curl -fsSL -o "$MONOBASE_PREFIX/bin/pget-bin" "$PGET_URL"
-    chmod +x "$MONOBASE_PREFIX/bin/pget-bin"
-    "$MONOBASE_PREFIX/bin/pget-bin" version
-
-    # PGET FUSE wrapper
-    cp /opt/r8/monobase/pget "$MONOBASE_PREFIX/bin/pget"
-
-    log "Running builder..."
-    uv run --python "$MONOBASE_PYTHON" --with requests /opt/r8/monobase/build.py "$@"
-
-    # Inside K8S
-    # Write done file to signal pod ready
-    # Sleep keep pod alive
-    if [ -n "${KUBERNETES_SERVICE_HOST:-}" ]; then
-        touch "$DONE_FILE"
-        sleep 86400
-    fi
-}
-
-export PATH="$MONOBASE_PREFIX/bin:$PATH"
 
 model() {
     # shellcheck disable=SC1091
@@ -52,6 +17,6 @@ model() {
 }
 
 case $HOSTNAME in
-    monobase-*) builder "$@" ;;
+    monobase-*) /opt/r8/monobase/build.sh "$@" ;;
     *) model "$@" ;;
 esac


### PR DESCRIPTION
This allows as to build a mini monobase with 5 ENV vars and 1 RUN command (layer). As the foundation of fast push local Docker build.
https://github.com/replicate/monobase/pull/8/files#diff-faabba7d94dd25d494050fd32d93f368012fe9c1a6da3bbf28eebea3b3a2c2f9

Next step would be building a user `venv`, similar to `/root/.pyenv` in current Cog. We would check and exclude dependencies already exist in pre-installed Cog & monobase `venv`.