### PR TITLE
Add diff tool

### DIFF
--- a/src/diff.py
+++ b/src/diff.py
@@ -1,0 +1,53 @@
+import argparse
+import os.path
+
+from util import Version, parse_requirements
+
+parser = argparse.ArgumentParser(description='Diff monobase requirements')
+parser.add_argument('id', nargs=2, type=int, help='Generation ID')
+
+
+def diff_versions(
+    venv: str, vs0: dict[str, str | Version], vs1: dict[str, str | Version]
+) -> None:
+    for k in sorted(list(vs0.keys()) + list(vs1.keys())):
+        if k in vs0 and k not in vs1:
+            print(f'{venv}\t{k}\t{vs0[k]}\t-')
+        elif k not in vs0 and k in vs1:
+            print(f'{venv}\t{k}\t-\t{vs1[k]}')
+        elif vs0[k] != vs1[k]:
+            print(f'{venv}\t{k}\t{vs0[k]}\t{vs1[k]}')
+
+
+def diff(id0: int, id1: int) -> None:
+    rdir = os.path.join(os.path.dirname(__file__), 'requirements')
+    g0, g1 = f'g{id0:05d}', f'g{id1:05d}'
+    rdir0 = os.path.join(rdir, g0)
+    rdir1 = os.path.join(rdir, g1)
+
+    venvs0 = os.listdir(rdir0)
+    venvs1 = os.listdir(rdir1)
+
+    venvs = sorted(set(venvs0) - set(venvs1))
+    if len(venvs) > 0:
+        for v in venvs:
+            v = v.rstrip('.txt')
+            print(f'{v}\t-')
+
+    venvs = sorted(set(venvs1) - set(venvs0))
+    if len(venvs) > 0:
+        for v in venvs:
+            v = v.rstrip('.txt')
+            print(f'-\t{v}')
+
+    for venv in sorted(set(venvs0).intersection(set(venvs1))):
+        with open(os.path.join(rdir0, venv), 'r') as f:
+            vs0 = parse_requirements(f.read())
+        with open(os.path.join(rdir1, venv), 'r') as f:
+            vs1 = parse_requirements(f.read())
+        diff_versions(venv.rstrip('.txt'), vs0, vs1)
+
+
+if __name__ == '__main__':
+    args = parser.parse_args()
+    diff(args.id[0], args.id[1])

--- a/src/util.py
+++ b/src/util.py
@@ -80,6 +80,27 @@ def desc_version_key(d: dict[str, str]) -> list[tuple[str, str]]:
     return sorted(d.items(), key=lambda kv: Version.parse(kv[0]), reverse=True)
 
 
+def parse_requirements(req: str) -> dict[str, str | Version]:
+    versions: dict[str, str | Version] = {}
+    for line in req.splitlines():
+        line = line.strip()
+        if line == '' or line.startswith('#') or line.startswith('--'):
+            continue
+        if '==' in line:
+            parts = line.split('==')
+        elif '@' in line:
+            parts = line.split('@')
+        else:
+            raise ValueError(f'invalid requirement: {line}')
+        assert len(parts) == 2, f'invalid requirement: {line}'
+        vs = parts[1].strip()
+        try:
+            versions[parts[0].strip()] = Version.parse(vs)
+        except ValueError:
+            versions[parts[0].strip()] = vs
+    return versions
+
+
 def setup_logging() -> None:
     logger = logging.getLogger()
     logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
`python3 src/diff.py 9 10` shows that the latest g00010:
* bumps pip 24.2 => 24.3.1 in every venv
* adds `nvidia-*` (pip package with `lib*.so` only) for torch < 2.2.0
* bumps the following for `torch2.6.0.dev20240918`, among which `numpy 1.x => 2.x` is curious

```
filelock        3.13.1  3.16.1
fsspec  2024.6.1        2024.10.0
networkx        3.3     3.4.2
numpy   1.26.4  2.1.2
pillow  9.3.0   11.0.0  # python3.11
pillow  10.1.0  11.0.0  # python3.12
```

Going forward we should probably always run on the last 2 when adding new generation, and double check major bumps.