### PR TITLE
Install torch nightly from wheel URLs

### DIFF
--- a/src/monobase/monogen.py
+++ b/src/monobase/monogen.py
@@ -28,11 +28,8 @@ TEST_MONOGENS: list[MonoGen] = [
         python={'3.12': '3.12.7'},
         torch=[
             '2.4.1',
-            # NOTE(meatballhat): This is turned off until we can figure out how to handle
-            # nightlies better since the torch package index only retains ~2 months of
-            # versions:
-            ## Nightly
-            #'2.6.0.dev20240918'
+            # Nightly
+            '2.6.0.dev20240918',
         ],
         pip_pkgs=SEED_PKGS,
     ),

--- a/src/monobase/torch.py
+++ b/src/monobase/torch.py
@@ -30,11 +30,8 @@ torch_specs_dict = {
 }
 
 torch_deps_dict = {
-    # NOTE(meatballhat): This is turned off until we can figure out how to handle
-    # nightlies better since the torch package index only retains ~2 months of
-    # versions:
-    ## Nightly
-    #'2.6.0.dev20240918': TorchDeps('2.5.0.dev20240918', '0.20.0.dev20240918'),
+    # Nightly
+    '2.6.0.dev20240918': TorchDeps('2.5.0.dev20240918', '0.20.0.dev20240918'),
     # Releases
     '2.4.1': TorchDeps('2.4.1', '0.19.1'),
     '2.4.0': TorchDeps('2.4.0', '0.19.0'),


### PR DESCRIPTION
Install torch nightly builds with `@ https://...` so that older builds removed from index after 60 days are still installable.