### PR TITLE
Handle cog overrides with `>=` operator

### DIFF
--- a/script/test.sh
+++ b/script/test.sh
@@ -108,6 +108,41 @@ docker run --rm \
 read -r -d '' SCRIPT << EOF || :
 import cog
 assert cog.__file__.startswith('/srv/r8/monobase/cog'), f'cog is not pre-installed: {cog.__file__}'
+assert cog.__version__ == '0.11.3', f'cog.__version__ is not 0.11.3: {cog.__version__}'
+print('PASS: Requiring cog>=0.11.3 matches pre-installed cog==0.11.3')
+EOF
+docker run --rm \
+    --volume "$PWD/src/monobase:/opt/r8/monobase" \
+    --volume "$PWD/build/monobase:/srv/r8/monobase" \
+    --env R8_COG_VERSION='>=0.11.3' \
+    --env R8_CUDA_VERSION=12.4 \
+    --env R8_CUDNN_VERSION=9 \
+    --env R8_PYTHON_VERSION=3.12 \
+    --env R8_TORCH_VERSION=2.4.1 \
+    monobase:latest \
+    python -c "$SCRIPT"
+
+read -r -d '' SCRIPT << EOF || :
+import cog
+assert cog.__file__.startswith('/root/cog'), f'cog is not installed on the fly: {cog.__file__}'
+assert cog.__version__ != '0.11.3', f'cog.__version__ not 0.11.3: {cog.__version__}'
+assert cog.__version__ >= '0.11.6', f'cog.__version__ not >= 0.11.6: {cog.__version__}'
+print('PASS: Requiring cog>=0.11.6 installs latest on demand')
+EOF
+docker run --rm \
+    --volume "$PWD/src/monobase:/opt/r8/monobase" \
+    --volume "$PWD/build/monobase:/srv/r8/monobase" \
+    --env R8_COG_VERSION='>=0.11.6' \
+    --env R8_CUDA_VERSION=12.4 \
+    --env R8_CUDNN_VERSION=9 \
+    --env R8_PYTHON_VERSION=3.12 \
+    --env R8_TORCH_VERSION=2.4.1 \
+    monobase:latest \
+    python -c "$SCRIPT"
+
+read -r -d '' SCRIPT << EOF || :
+import cog
+assert cog.__file__.startswith('/srv/r8/monobase/cog'), f'cog is not pre-installed: {cog.__file__}'
 assert cog.__version__ == '0.11.2.dev71+g00b98bc90b', f'cog.__version__ is not 0.11.2.dev71+g00b98bc90b: {cog.__version__}'
 print('PASS: Pre-installed cog==cog @ https://...')
 EOF

--- a/src/monobase/env.sh
+++ b/src/monobase/env.sh
@@ -45,6 +45,15 @@ else
             name=$(printf '%s' "$R8_COG_VERSION" | sha256sum | cut -c 1-8)
             pkg="cog @ $R8_COG_VERSION"
             ;;
+        \>=*)
+            # NOTE(meatballhat): A value of R8_COG_VERSION>=0.11.3 means that a
+            # pre-installed version 0.11.3 should work, so removing the '>=' operator when
+            # defining 'name' allows the cached installation to be used. The 'pkg'
+            # variable passes through the '>=' operator in case a cached installation is
+            # not found.
+            name="$(echo "$R8_COG_VERSION" | sed 's/^>=//')"
+            pkg="cog${R8_COG_VERSION}"
+            ;;
         *)
             name=$R8_COG_VERSION
             pkg="cog==$R8_COG_VERSION"


### PR DESCRIPTION
to attempt to use cached installation, falling back to `uv pip install`. The goal here is to behave the same way as `uv pip install` but with the extra knowledge of cached versions, e.g.:

```
$ uv pip install cog==0.11.3
Resolved 25 packages in 165ms
Installed 1 package in 2ms
 + cog==0.11.3

$ uv pip show cog
Name: cog
Version: 0.11.3
Location: /Users/me/Downloads/blep2/.venv/lib/python3.13/site-packages
Requires: attrs, fastapi, pydantic, pyyaml, requests, structlog,
typing-extensions, uvicorn
Required-by:

$ uv pip install 'cog>=0.11.3'
Audited 1 package in 2ms
```

Connected to PLAT-611