### PR TITLE
Add a docs-only shim in case of running `python -m monobase`

### DIFF
--- a/src/monobase/__main__.py
+++ b/src/monobase/__main__.py
@@ -1,0 +1,21 @@
+import sys
+import textwrap
+
+if __name__ == '__main__':
+    print(
+        textwrap.dedent(
+            """\
+    Running monobase directly does not do anything 🙀.
+    You probably want one of these instead:
+
+        python -m monobase.build
+
+        python -m monobase.diff
+
+        python -m monobase.monogen
+
+        python -m monobase.update
+    """
+        )
+    )
+    sys.exit(2)


### PR DESCRIPTION
(like I just did) that tells a human (like me) what they probably wanted to do instead.