### PR TITLE
Include timestamp and span-compatible attributes in done files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /build/
 requirements-test
 __pycache__
+/src/monobase/_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,18 @@
 [project]
 name = "monobase"
-version = "0.1.0"
 description = "Replicate monolithic base dependency build friend"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = []
 license = {file = "LICENSE"}
+dynamic = ["version"]
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/monobase/_version.py"

--- a/script/test
+++ b/script/test
@@ -37,6 +37,7 @@ test() {
         -d) [ -d "$f" ] || r=1 ;;
         -f) [ -f "$f" ] || r=1 ;;
         -h) [ -h "$f" ] || r=1 ;;
+        -s) [ -s "$f" ] || r=1 ;;
         -x) [ -x "$f" ] || r=1 ;;
     esac
 
@@ -44,7 +45,17 @@ test() {
         echo "PASS: [ $op /srv/r8/monobase/$2 ]"
     else
         echo "FAIL: [ $op /srv/r8/monobase/$2 ]"
-        fail=$((fail+1))
+        fail=$((fail + 1))
+    fi
+}
+
+is-json() {
+    f="$PWD/build/monobase/$1"
+    if jq < "$f" >/dev/null; then
+        echo "PASS: is-json /srv/r8/monobase/$1"
+    else
+        echo "FAIL: is-json /srv/r8/monobase/$1"
+        fail=$((fail + 1))
     fi
 }
 
@@ -52,18 +63,23 @@ test() {
 test -x 'bin/uv'
 test -x 'bin/pget'
 test -h 'cog/latest'
-test -f 'cog/latest/.done'
+test -s 'cog/latest/.done'
+is-json 'cog/latest/.done'
 test -h 'cog/latest/default-python3.12'
 test -h 'monobase/latest'
 test -d 'monobase/g00000'
-test -f 'monobase/g00000/.done'
+test -s 'monobase/g00000/.done'
+is-json 'monobase/g00000/.done'
 test -h 'monobase/g00000/cuda12.4'
-test -f 'monobase/g00000/cuda12.4/.done'
+test -s 'monobase/g00000/cuda12.4/.done'
+is-json 'monobase/g00000/cuda12.4/.done'
 test -h 'monobase/g00000/cudnn9-cuda12'
-test -f 'monobase/g00000/cudnn9-cuda12/.done'
+test -s 'monobase/g00000/cudnn9-cuda12/.done'
+is-json 'monobase/g00000/cudnn9-cuda12/.done'
 test -d 'monobase/g00000/ld.so.cache.d'
 test -d 'monobase/g00000/python3.12-torch2.4.1-cu124'
-test -f 'monobase/g00000/python3.12-torch2.4.1-cu124/.done'
+test -s 'monobase/g00000/python3.12-torch2.4.1-cu124/.done'
+is-json 'monobase/g00000/python3.12-torch2.4.1-cu124/.done'
 
 if [ "$fail" -gt 0 ]; then
     exit 1

--- a/script/test-mini
+++ b/script/test-mini
@@ -41,6 +41,7 @@ test() {
         -d) [ -d "$f" ] || r=1 ;;
         -f) [ -f "$f" ] || r=1 ;;
         -h) [ -h "$f" ] || r=1 ;;
+        -s) [ -s "$f" ] || r=1 ;;
         -x) [ -x "$f" ] || r=1 ;;
     esac
 
@@ -48,7 +49,17 @@ test() {
         echo "PASS: [ $op /srv/r8/monobase/$2 ]"
     else
         echo "FAIL: [ $op /srv/r8/monobase/$2 ]"
-        fail=$((fail+1))
+        fail=$((fail + 1))
+    fi
+}
+
+is-json() {
+    f="$PWD/build/monobase/$1"
+    if jq < "$f" >/dev/null; then
+        echo "PASS: is-json /srv/r8/monobase/$1"
+    else
+        echo "FAIL: is-json /srv/r8/monobase/$1"
+        fail=$((fail + 1))
     fi
 }
 
@@ -56,20 +67,26 @@ test() {
 test -x 'bin/uv'
 test -x 'bin/pget'
 test -h 'cog/latest'
-test -f 'cog/latest/.done'
+test -s 'cog/latest/.done'
+is-json 'cog/latest/.done'
 test -h 'cog/latest/default-python3.12'
 test -h 'monobase/latest'
 test -d 'monobase/g00000'
-test -f 'monobase/g00000/.done'
+test -s 'monobase/g00000/.done'
+is-json 'monobase/g00000/.done'
 test -h 'monobase/g00000/cuda12.4'
-test -f 'monobase/g00000/cuda12.4/.done'
+test -s 'monobase/g00000/cuda12.4/.done'
+is-json 'monobase/g00000/cuda12.4/.done'
 test -h 'monobase/g00000/cudnn9-cuda12'
-test -f 'monobase/g00000/cudnn9-cuda12/.done'
+test -s 'monobase/g00000/cudnn9-cuda12/.done'
+is-json 'monobase/g00000/cudnn9-cuda12/.done'
 test -d 'monobase/g00000/ld.so.cache.d'
 test -d 'monobase/g00000/python3.12-torch2.4.1-cu124'
-test -f 'monobase/g00000/python3.12-torch2.4.1-cu124/.done'
+test -s 'monobase/g00000/python3.12-torch2.4.1-cu124/.done'
+is-json 'monobase/g00000/python3.12-torch2.4.1-cu124/.done'
 test -d 'user'
-test -f 'user/.done'
+test -s 'user/.done'
+is-json 'user/.done'
 test -f 'requirements-cog.txt'
 test -f 'requirements-mono.txt'
 test -f 'requirements-user.txt'

--- a/src/monobase/build.py
+++ b/src/monobase/build.py
@@ -17,8 +17,8 @@ from monobase.util import (
     add_arguments,
     desc_version,
     desc_version_key,
-    is_done,
     mark_done,
+    require_done_or_rm,
     setup_logging,
 )
 from monobase.uv import install_venv
@@ -88,7 +88,7 @@ parser.add_argument(
 
 def build_generation(args: argparse.Namespace, mg: MonoGen) -> None:
     gdir = os.path.join(args.prefix, 'monobase', f'g{mg.id:05d}')
-    if is_done(gdir):
+    if require_done_or_rm(gdir):
         return
 
     logging.info(f'Building monobase generation {mg.id}...')

--- a/src/monobase/cog.py
+++ b/src/monobase/cog.py
@@ -7,7 +7,7 @@ import re
 import shutil
 import subprocess
 
-from monobase.util import is_done, mark_done
+from monobase.util import mark_done, require_done_or_rm
 
 LINK_REGEX = re.compile(r'<(?P<url>https://[^>]+)>; rel="next"')
 
@@ -66,7 +66,7 @@ def install_cogs(args: argparse.Namespace, python_versions: list[str]) -> None:
     sha256 = cog_gen_hash(cog_versions, args.default_cog_version, python_versions)[:8]
     gid = f'g{sha256}'
     gdir = os.path.join(cdir, gid)
-    if is_done(gdir):
+    if require_done_or_rm(gdir):
         return
 
     logging.info(f'Installing cog generation {gid} in {gdir}...')

--- a/src/monobase/cog.py
+++ b/src/monobase/cog.py
@@ -85,7 +85,14 @@ def install_cogs(args: argparse.Namespace, python_versions: list[str]) -> None:
         os.remove(latest)
     os.symlink(gid, latest)
 
-    mark_done(gdir)
+    mark_done(
+        gdir,
+        kind='cog',
+        id=gid,
+        versions=cog_versions,
+        default_version=args.default_cog_version,
+        python_versions=python_versions,
+    )
 
     for g in os.listdir(cdir):
         if g in {'latest', gid}:

--- a/src/monobase/cuda.py
+++ b/src/monobase/cuda.py
@@ -69,7 +69,7 @@ def install_cuda(args: argparse.Namespace, version: str) -> str:
         return cdir
     if args.skip_cuda:
         os.makedirs(cdir, exist_ok=True)
-        mark_done(cdir)
+        mark_done(cdir, kind='cuda', version=version, skipped=True)
         logging.info(f'CUDA {version} skipped in {cdir}')
         return cdir
 
@@ -111,7 +111,7 @@ def install_cuda(args: argparse.Namespace, version: str) -> str:
     cmd = ['find', cdir, '-name', 'lib*.a', '-delete']
     subprocess.run(cmd, check=True)
 
-    mark_done(cdir)
+    mark_done(cdir, kind='cuda', version=version, url=cuda.url)
     logging.info(f'CUDA {version} installed in {cdir}')
     return cdir
 
@@ -123,7 +123,7 @@ def install_cudnn(args: argparse.Namespace, version: str, cuda_major: str) -> st
         return cdir
     if args.skip_cuda:
         os.makedirs(cdir, exist_ok=True)
-        mark_done(cdir)
+        mark_done(cdir, kind='cudnn', version=version, skipped=True)
         logging.info(f'CuDNN {key} skipped in {cdir}')
         return cdir
 
@@ -145,6 +145,6 @@ def install_cudnn(args: argparse.Namespace, version: str, cuda_major: str) -> st
     cmd = ['tar', '-xf', file, '--strip-components=1', '--exclude=lib*.a', '-C', cdir]
     subprocess.run(cmd, check=True)
 
-    mark_done(cdir)
+    mark_done(cdir, kind='cudnn', version=version, url=cudnn.url)
     logging.info(f'CuDNN {key} installed in {cdir}')
     return cdir

--- a/src/monobase/cuda.py
+++ b/src/monobase/cuda.py
@@ -8,7 +8,7 @@ import urllib.parse
 from dataclasses import dataclass
 
 from monobase.urls import cuda_urls, cudnn_urls
-from monobase.util import Version, is_done, mark_done
+from monobase.util import Version, mark_done, require_done_or_rm
 
 
 @dataclass(frozen=True, order=True)
@@ -65,7 +65,7 @@ CUDNNS: dict[str, CuDNN] = build_cudnns()
 
 def install_cuda(args: argparse.Namespace, version: str) -> str:
     cdir = os.path.join(args.prefix, 'cuda', f'cuda-{version}')
-    if is_done(cdir):
+    if require_done_or_rm(cdir):
         return cdir
     if args.skip_cuda:
         os.makedirs(cdir, exist_ok=True)
@@ -119,7 +119,7 @@ def install_cuda(args: argparse.Namespace, version: str) -> str:
 def install_cudnn(args: argparse.Namespace, version: str, cuda_major: str) -> str:
     key = f'{version}-cuda{cuda_major}'
     cdir = os.path.join(args.prefix, 'cuda', f'cudnn-{key}')
-    if is_done(cdir):
+    if require_done_or_rm(cdir):
         return cdir
     if args.skip_cuda:
         os.makedirs(cdir, exist_ok=True)

--- a/src/monobase/user.py
+++ b/src/monobase/user.py
@@ -110,5 +110,11 @@ def build_user_venv(args: argparse.Namespace) -> None:
     cmd = [uv, 'pip', 'install', '--no-deps', '--requirement', user_req_path]
     subprocess.run(cmd, check=True, env=env)
 
-    mark_done(udir)
+    mark_done(
+        udir,
+        kind='user',
+        python_version=python_version,
+        torch_version=torch_version,
+        cuda_version=cuda_version,
+    )
     logging.info(f'User venv installed in {udir}')

--- a/src/monobase/user.py
+++ b/src/monobase/user.py
@@ -4,7 +4,7 @@ import os.path
 import subprocess
 from typing import Optional
 
-from monobase.util import Version, is_done, mark_done, parse_requirements
+from monobase.util import Version, mark_done, parse_requirements, require_done_or_rm
 from monobase.uv import cuda_suffix
 
 
@@ -18,7 +18,7 @@ def freeze(uv: str, vdir: str) -> str:
 
 def build_user_venv(args: argparse.Namespace) -> None:
     udir = os.path.join(args.prefix, 'user')
-    if is_done(udir):
+    if require_done_or_rm(udir):
         return
 
     logging.info(f'Building user venv {udir}...')

--- a/src/monobase/util.py
+++ b/src/monobase/util.py
@@ -9,7 +9,7 @@ import sys
 from dataclasses import dataclass
 from typing import Iterable
 
-DONE_FILE_BASENAME = ".done"
+DONE_FILE_BASENAME = '.done'
 MINIMUM_VALID_JSON_SIZE = len('{"version":"dev"}')
 VERSION_REGEX = re.compile(
     r'^(?P<major>\d+)(\.(?P<minor>\d+)(\.(?P<patch>\d+)(\.(?P<extra>.+))?)?)?'

--- a/src/monobase/uv.py
+++ b/src/monobase/uv.py
@@ -170,5 +170,12 @@ def install_venv(
     env['VIRTUAL_ENV'] = vdir
     subprocess.run(cmd, check=True, env=env)
 
-    mark_done(vdir)
+    mark_done(
+        vdir,
+        kind='venv',
+        python_version=python_version,
+        python_full_version=python_full_version,
+        torch_version=torch_version,
+        cuda_version=cuda_version,
+    )
     logging.info(f'Python {python_version} Torch {torch_version} installed in {vdir}')

--- a/src/monobase/uv.py
+++ b/src/monobase/uv.py
@@ -4,7 +4,7 @@ import os.path
 import subprocess
 
 from monobase.torch import torch_deps, torch_specs
-from monobase.util import Version, is_done, mark_done
+from monobase.util import Version, mark_done, require_done_or_rm
 
 
 def cuda_suffix(cuda_version: str) -> str:
@@ -153,7 +153,7 @@ def install_venv(
 
     venv = f'python{python_version}-torch{torch_version}-{cuda_suffix(cuda_version)}'
     vdir = os.path.join(gdir, venv)
-    if is_done(vdir):
+    if require_done_or_rm(vdir):
         return
 
     logging.info(f'Creating venv {venv}...')


### PR DESCRIPTION
so that we can pass along more context through `director` and generally depend on more than an empty file.

~**Please note**: this also includes a behavior change to `is_done` that no longer deletes the directory tree when `.done` is not present. I couldn't come up with a reason for why we would want this outside of testing. I'm happy to learn that it's important and we should keep it that way 😇 (although if it needs to be kept that way then I'd like it to have a different name).~

**Update**: What was previously `monobase.util:is_done` is now `monobase.util:require_done_or_rm`

Connected to PLAT-555