### PR TITLE
Export `R8_ATTRIBUTES_FILES` in model env

### DIFF
--- a/src/monobase/activate.sh
+++ b/src/monobase/activate.sh
@@ -113,3 +113,5 @@ export LIBRARY_PATH="$CUDA_PATH/lib64/stubs"
 
 LD_CACHE_PATH="$MONOBASE_PATH/ld.so.cache.d/cuda$R8_CUDA_VERSION-cudnn$R8_CUDNN_VERSION-python$R8_PYTHON_VERSION"
 cp -f "$LD_CACHE_PATH" /etc/ld.so.cache
+
+export R8_ATTRIBUTES_FILES="${COG_VENV}/.done ${CUDA_PATH}/.done ${CUDNN_PATH}/.done ${VIRTUAL_ENV}/.done"


### PR DESCRIPTION
to be passed along to other observability layers.

Connected to PLAT-589