### PR TITLE
Set `done` as a valid alphanumeric label

### DIFF
--- a/src/monobase/build.sh
+++ b/src/monobase/build.sh
@@ -46,7 +46,7 @@ uv run --python "$MONOBASE_PYTHON" python -m monobase.build "$@"
 # - Sleep keep pod alive
 if [ -n "${KUBERNETES_SERVICE_HOST:-}" ]; then
     touch "$DONE_FILE"
-    printf "done=%s\n" "$(date --iso-8601=seconds --utc)" |
+    printf "done=%s\n" "$(date --utc '+%Y%m%dT%H%M%SZ')" |
         tee /etc/kubernetes/node-feature-discovery/features.d/monobase
     exec sleep infinity
 fi


### PR DESCRIPTION
given `nfd-worker` complaining

```
ignoring invalid feature value monobase-done=2024-12-10T23:03:11+00:00: [a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character
```

Connected to PLAT-689