### PR TITLE
Mark done on latest; move feature labeling into build

### DIFF
--- a/script/test
+++ b/script/test
@@ -12,12 +12,13 @@ cd "$(git rev-parse --show-toplevel)"
 uv run --python "$MONOBASE_PYTHON" python -m monobase.update --environment test
 
 # Build test PREFIX
-mkdir -p build/monobase build/cache
+mkdir -p build/monobase build/cache build/nfd-features.d
 docker run --rm \
     --user "$(id -u):$(id -g)" \
     --volume "$PWD/src/monobase:/opt/r8/monobase" \
     --volume "$PWD/build/monobase:/srv/r8/monobase" \
     --volume "$PWD/build/cache:/var/cache/monobase" \
+    --volume "$PWD/build/nfd-features.d:/etc/kubernetes/node-feature-discovery/features.d" \
     monobase:latest \
     /opt/r8/monobase/build.sh \
     --environment test \
@@ -26,12 +27,13 @@ docker run --rm \
     0.11.3 \
     https://github.com/replicate/cog/archive/00b98bc90bb784102243b7aec41ad1cbffaefece.zip \
     --default-cog-version 0.11.3 \
+    --write-node-feature-discovery-labels \
     "$@"
 
 fail=0
 test() {
     op="$1"
-    f="$PWD/build/monobase/$2"
+    f="$PWD/build/$2"
     r=0
     case "$op" in
         -d) [ -d "$f" ] || r=1 ;;
@@ -50,7 +52,7 @@ test() {
 }
 
 is-json() {
-    f="$PWD/build/monobase/$1"
+    f="$PWD/build/$1"
     if jq < "$f" >/dev/null; then
         echo "PASS: is-json /srv/r8/monobase/$1"
     else
@@ -59,27 +61,30 @@ is-json() {
     fi
 }
 
-# Test /srv/r8/monobase structure
-test -x 'bin/uv'
-test -x 'bin/pget'
-test -h 'cog/latest'
-test -s 'cog/latest/.done'
-is-json 'cog/latest/.done'
-test -h 'cog/latest/default-python3.12'
-test -h 'monobase/latest'
-test -d 'monobase/g00000'
-test -s 'monobase/g00000/.done'
-is-json 'monobase/g00000/.done'
-test -h 'monobase/g00000/cuda12.4'
-test -s 'monobase/g00000/cuda12.4/.done'
-is-json 'monobase/g00000/cuda12.4/.done'
-test -h 'monobase/g00000/cudnn9-cuda12'
-test -s 'monobase/g00000/cudnn9-cuda12/.done'
-is-json 'monobase/g00000/cudnn9-cuda12/.done'
-test -d 'monobase/g00000/ld.so.cache.d'
-test -d 'monobase/g00000/python3.12-torch2.4.1-cu124'
-test -s 'monobase/g00000/python3.12-torch2.4.1-cu124/.done'
-is-json 'monobase/g00000/python3.12-torch2.4.1-cu124/.done'
+# Test ./build structure which maps to /srv/r8/monobase in container
+test -s 'monobase/.done'
+is-json 'monobase/.done'
+test -x 'monobase/bin/uv'
+test -x 'monobase/bin/pget'
+test -h 'monobase/cog/latest'
+test -s 'monobase/cog/latest/.done'
+is-json 'monobase/cog/latest/.done'
+test -h 'monobase/cog/latest/default-python3.12'
+test -h 'monobase/monobase/latest'
+test -d 'monobase/monobase/g00000'
+test -s 'monobase/monobase/g00000/.done'
+is-json 'monobase/monobase/g00000/.done'
+test -h 'monobase/monobase/g00000/cuda12.4'
+test -s 'monobase/monobase/g00000/cuda12.4/.done'
+is-json 'monobase/monobase/g00000/cuda12.4/.done'
+test -h 'monobase/monobase/g00000/cudnn9-cuda12'
+test -s 'monobase/monobase/g00000/cudnn9-cuda12/.done'
+is-json 'monobase/monobase/g00000/cudnn9-cuda12/.done'
+test -d 'monobase/monobase/g00000/ld.so.cache.d'
+test -d 'monobase/monobase/g00000/python3.12-torch2.4.1-cu124'
+test -s 'monobase/monobase/g00000/python3.12-torch2.4.1-cu124/.done'
+is-json 'monobase/monobase/g00000/python3.12-torch2.4.1-cu124/.done'
+test -s 'nfd-features.d/monobase'
 
 if [ "$fail" -gt 0 ]; then
     exit 1

--- a/script/test-mini
+++ b/script/test-mini
@@ -91,7 +91,6 @@ is-json 'monobase/user/.done'
 test -f 'monobase/requirements-cog.txt'
 test -f 'monobase/requirements-mono.txt'
 test -f 'monobase/requirements-user.txt'
-test -s 'nfd-features.d/monobase'
 
 if [ "$fail" -gt 0 ]; then
     exit 1

--- a/script/test-mini
+++ b/script/test-mini
@@ -36,7 +36,7 @@ docker run --rm \
 fail=0
 test() {
     op="$1"
-    f="$PWD/build/monobase/$2"
+    f="$PWD/build/$2"
     r=0
     case "$op" in
         -d) [ -d "$f" ] || r=1 ;;
@@ -55,7 +55,7 @@ test() {
 }
 
 is-json() {
-    f="$PWD/build/monobase/$1"
+    f="$PWD/build/$1"
     if jq < "$f" >/dev/null; then
         echo "PASS: is-json /srv/r8/monobase/$1"
     else
@@ -65,33 +65,33 @@ is-json() {
 }
 
 # Test /srv/r8/monobase structure
-test -x 'bin/uv'
-test -x 'bin/pget'
-test -h 'cog/latest'
-test -s 'cog/latest/.done'
-is-json 'cog/latest/.done'
-test -h 'cog/latest/default-python3.12'
-test -h 'monobase/latest'
-test -d 'monobase/g00000'
-test -s 'monobase/g00000/.done'
-is-json 'monobase/g00000/.done'
-test -h 'monobase/g00000/cuda12.4'
-test -s 'monobase/g00000/cuda12.4/.done'
-is-json 'monobase/g00000/cuda12.4/.done'
-test -h 'monobase/g00000/cudnn9-cuda12'
-test -s 'monobase/g00000/cudnn9-cuda12/.done'
-is-json 'monobase/g00000/cudnn9-cuda12/.done'
-test -d 'monobase/g00000/ld.so.cache.d'
-test -d 'monobase/g00000/python3.12-torch2.4.1-cu124'
-test -s 'monobase/g00000/python3.12-torch2.4.1-cu124/.done'
-is-json 'monobase/g00000/python3.12-torch2.4.1-cu124/.done'
-test -d 'user'
-test -s 'user/.done'
-is-json 'user/.done'
-test -f 'requirements-cog.txt'
-test -f 'requirements-mono.txt'
-test -f 'requirements-user.txt'
-
+test -x 'monobase/bin/uv'
+test -x 'monobase/bin/pget'
+test -h 'monobase/cog/latest'
+test -s 'monobase/cog/latest/.done'
+is-json 'monobase/cog/latest/.done'
+test -h 'monobase/cog/latest/default-python3.12'
+test -h 'monobase/monobase/latest'
+test -d 'monobase/monobase/g00001'
+test -s 'monobase/monobase/g00001/.done'
+is-json 'monobase/monobase/g00001/.done'
+test -h 'monobase/monobase/g00001/cuda12.4'
+test -s 'monobase/monobase/g00001/cuda12.4/.done'
+is-json 'monobase/monobase/g00001/cuda12.4/.done'
+test -h 'monobase/monobase/g00001/cudnn9-cuda12'
+test -s 'monobase/monobase/g00001/cudnn9-cuda12/.done'
+is-json 'monobase/monobase/g00001/cudnn9-cuda12/.done'
+test -d 'monobase/monobase/g00001/ld.so.cache.d'
+test -d 'monobase/monobase/g00001/python3.12-torch2.4.1-cu124'
+test -s 'monobase/monobase/g00001/python3.12-torch2.4.1-cu124/.done'
+is-json 'monobase/monobase/g00001/python3.12-torch2.4.1-cu124/.done'
+test -d 'monobase/user'
+test -s 'monobase/user/.done'
+is-json 'monobase/user/.done'
+test -f 'monobase/requirements-cog.txt'
+test -f 'monobase/requirements-mono.txt'
+test -f 'monobase/requirements-user.txt'
+test -s 'nfd-features.d/monobase'
 
 if [ "$fail" -gt 0 ]; then
     exit 1

--- a/src/monobase/build.sh
+++ b/src/monobase/build.sh
@@ -37,16 +37,5 @@ if [ -z "${NO_REINSTALL:-}" ]; then
     cp /opt/r8/monobase/pget "$MONOBASE_PREFIX/bin/pget"
 fi
 
-log "Running builder..."
-uv run --python "$MONOBASE_PYTHON" python -m monobase.build "$@"
-
-# When running in K8S:
-# - Write done file to signal pod ready
-# - Write the done timestamp to node feature discovery label
-# - Sleep keep pod alive
-if [ -n "${KUBERNETES_SERVICE_HOST:-}" ]; then
-    touch "$DONE_FILE"
-    printf "done=%s\n" "$(date --utc '+%Y%m%dT%H%M%SZ')" |
-        tee /etc/kubernetes/node-feature-discovery/features.d/monobase
-    exec sleep infinity
-fi
+log "Running monobase.build..."
+exec uv run --python "$MONOBASE_PYTHON" python -m monobase.build "$@"

--- a/src/monobase/monogen.py
+++ b/src/monobase/monogen.py
@@ -33,6 +33,19 @@ TEST_MONOGENS: list[MonoGen] = [
         ],
         pip_pkgs=SEED_PKGS,
     ),
+    MonoGen(
+        id=1,
+        cuda={'12.4': '12.4.1_550.54.15'},
+        cudnn={'9': '9.1.0.70'},
+        python={'3.12': '3.12.7', '3.13': '3.13.0'},
+        torch=[
+            '2.4.1',
+            '2.5.1',
+            # Nightly
+            '2.6.0.dev20240918',
+        ],
+        pip_pkgs=SEED_PKGS,
+    ),
 ]
 
 # Generations are immutable

--- a/src/monobase/util.py
+++ b/src/monobase/util.py
@@ -5,6 +5,7 @@ import glob
 import hashlib
 import json
 import logging
+import os
 import os.path
 import re
 import shutil
@@ -12,6 +13,8 @@ import sys
 from dataclasses import dataclass
 from typing import Iterable
 
+IN_KUBERNETES = os.environ.get('KUBERNETES_SERVICE_HOST') is not None
+NODE_FEATURE_LABEL_FILE = '/etc/kubernetes/node-feature-discovery/features.d/monobase'
 DONE_FILE_BASENAME = '.done'
 MINIMUM_VALID_JSON_SIZE = len('{"version":"dev"}')
 VERSION_REGEX = re.compile(


### PR DESCRIPTION
So that the latest generation being complete will add the necessary node label. I also moved the node feature discovery labeling into `monobase.build` and dropped the `sleep infinity` with the intent of changing the daemonset to run `monobase.build` in an init container and then switching the main container to run `pause` as is currently done for the `nfd-cgroup-version` component.

Connected to PLAT-689