### PR TITLE
Build and push `monobase-runtime` image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v3
       - run: ./script/build
+      - run: ./script/build-runtime
       - run: ./script/test
 
   test-mini:
@@ -50,9 +51,9 @@ jobs:
       - run: ./script/build
       - run: ./script/test-mini
 
-  build-release:
+  build-release-monobase:
     if: ${{ github.event_name != 'pull_request' }}
-    name: Build + release
+    name: Build + release monobase image
     needs:
       - check
       - test
@@ -65,3 +66,19 @@ jobs:
       image: monobase
       fetch-depth: 0
       build-args: BUILDKIT_CONTEXT_KEEP_GIT_DIR=1
+
+  build-release-monobase-runtime:
+    if: ${{ github.event_name != 'pull_request' }}
+    name: Build + release monobase-runtime image
+    needs:
+      - check
+      - test
+      - test-mini
+    permissions:
+      contents: read
+      id-token: write
+    uses: replicate/actions/.github/workflows/buildx.yml@main
+    with:
+      image: monobase-runtime
+      file: runtime.Dockerfile
+      fetch-depth: 0

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,71 +30,17 @@ ENV UV_COMPILE_BYTECODE=true
 ENV UV_LINK_MODE=hardlink
 ENV UV_PYTHON_PREFERENCE=only-managed
 
-# ca-certificates - HTTPS
-# curl - download uv, PGET, etc.
-# libxml2 - CUDA installer
-# rdfind - find duplicate CUDA .so files
-# xz-utils - CuDNN tarball
-
+ADD ./apt-dependencies.txt /tmp/apt-dependencies.txt
 RUN apt-get update \
-    && apt-get install -y \
-        ca-certificates \
-        curl \
-        libxml2 \
-        rdfind \
-        xz-utils \
-        build-essential \
-        ca-certificates \
-        cmake \
-        curl \
-        ffmpeg \
-        findutils \
-        g++ \
-        gcc \
-        git \
-        libavcodec-dev \
-        libbz2-dev \
-        libcairo2-dev \
-        libffi-dev \
-        libfontconfig1 \
-        libgirepository1.0-dev \
-        libgl1 \
-        libgl1-mesa-glx \
-        libglib2.0-0 \
-        liblzma-dev \
-        libncurses5-dev \
-        libncursesw5-dev \
-        libopencv-dev \
-        libreadline-dev \
-        libsm6 \
-        libsndfile1 \
-        libsqlite3-dev \
-        libssl-dev \
-        libunistring-dev \
-        libxext6 \
-        libxrender1 \
-        llvm \
-        make \
-        rsync \
-        sox \
-        tar \
-        tini \
-        tk-dev \
-        unzip \
-        wget \
-        xz-utils \
-        zip \
-        zlib1g-dev \
-        zstd \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get install -y $(grep -v '^#' </tmp/apt-dependencies.txt) \
+    && rm -rf /var/lib/apt/lists/* /tmp/apt-dependencies.txt
 
-RUN --mount=type=bind,from=build,target=/tmp/build-layer \
+RUN --mount=type=bind,from=build,target=/tmp/build-layer,ro \
     ln -sv /usr/bin/tini /sbin/tini \
     && mkdir -p /opt/r8 /tmp/r8 \
     && tar --strip-components=1 -C /tmp/r8 -xf $(find /tmp/build-layer/src/dist -name '*.tar.gz' | head -1) \
     && rsync -av /tmp/r8/src/monobase /opt/r8/ \
     && rm -rf /tmp/r8
 
-    
 ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["/opt/r8/monobase/build.sh", "--help"]

--- a/apt-dependencies.txt
+++ b/apt-dependencies.txt
@@ -1,0 +1,51 @@
+# ca-certificates - HTTPS
+# curl - download uv, PGET, etc.
+# libxml2 - CUDA installer
+# rdfind - find duplicate CUDA .so files
+# xz-utils - CuDNN tarball
+
+build-essential
+ca-certificates
+cmake
+curl
+ffmpeg
+findutils
+g++
+gcc
+git
+libavcodec-dev
+libbz2-dev
+libcairo2-dev
+libffi-dev
+libfontconfig1
+libgirepository1.0-dev
+libgl1
+libgl1-mesa-glx
+libglib2.0-0
+liblzma-dev
+libncurses5-dev
+libncursesw5-dev
+libopencv-dev
+libreadline-dev
+libsm6
+libsndfile1
+libsqlite3-dev
+libssl-dev
+libunistring-dev
+libxext6
+libxml2
+libxrender1
+llvm
+make
+rdfind
+rsync
+sox
+tar
+tini
+tk-dev
+unzip
+wget
+xz-utils
+zip
+zlib1g-dev
+zstd

--- a/runtime.Dockerfile
+++ b/runtime.Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:jammy
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV MONOBASE_PREFIX=/srv/r8/monobase
+ENV PATH=$MONOBASE_PREFIX/bin:$PATH
+ENV TZ=Etc/UTC
+
+ADD ./apt-dependencies.txt /tmp/apt-dependencies.txt
+RUN apt-get update \
+    && apt-get install -y $(grep -v '^#' </tmp/apt-dependencies.txt) \
+    && rm -rf /var/lib/apt/lists/* /tmp/apt-dependencies.txt
+
+RUN --mount=type=bind,src=../../,dst=/src,ro \
+    ln -sv /usr/bin/tini /sbin/tini \
+    && mkdir -p /opt/r8/monobase \
+    && ls -la /src/ \
+    && cp /src/src/monobase/activate.sh /src/src/monobase/exec.sh /opt/r8/monobase/
+
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["/opt/r8/monobase/exec.sh", "bash", "-l"]

--- a/script/build-runtime
+++ b/script/build-runtime
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Build runtime image
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+docker build --file runtime.Dockerfile --tag monobase-runtime:latest --platform=linux/amd64 .

--- a/script/debug
+++ b/script/debug
@@ -17,14 +17,23 @@ mkdir -p build/monobase build/cache
 : "${DEBUG_USER:=root:root}"
 : "${DEBUG_DIR:="/opt/r8"}"
 
+VOLUMES=(
+    --volume "${PWD}/build/monobase:/srv/r8/monobase"
+    --volume "${PWD}/build/cache:/var/cache/monobase"
+)
+if [[ -z "${DEBUG_NO_SRC_VOLUME:-}" ]]; then
+    VOLUMES=(
+        --volume "${PWD}/src/monobase:/opt/r8/monobase"
+        "${VOLUMES[@]}"
+    )
+fi
+
 set -x
 exec docker run --rm -it \
     --hostname debug \
     --user "${DEBUG_USER}" \
     --workdir "${DEBUG_DIR}" \
-    --volume "${PWD}/src/monobase:/opt/r8/monobase" \
-    --volume "${PWD}/build/monobase:/srv/r8/monobase" \
-    --volume "${PWD}/build/cache:/var/cache/monobase" \
+    "${VOLUMES[@]}" \
     --env R8_CUDA_VERSION="${R8_CUDA_VERSION:-"12.4"}" \
     --env R8_CUDNN_VERSION="${R8_CUDNN_VERSION:-"9"}" \
     --env R8_PYTHON_VERSION="${R8_PYTHON_VERSION:-"3.12"}" \


### PR DESCRIPTION
with minimal files present so as to minimize possibility of affecting models.

This is in preparation for introducing non-stdlib dependencies to monobase for the purpose of improving observability.

Connected to PLAT-555

Depends on replicate/actions#36