### PR TITLE
Support cog installation via file://

### DIFF
--- a/src/monobase/cog.py
+++ b/src/monobase/cog.py
@@ -47,7 +47,7 @@ def install_cog(
         }
     )
 
-    if cog_version.startswith('https://'):
+    if cog_version.startswith('https://') or cog_version.startswith('file://'):
         name = hash_str(cog_version)[:8]
         spec = f'cog@{cog_version}'
     else:


### PR DESCRIPTION
* When building a monobase on the cog client we feed cog in via a wheel file rather than an http
or pypi version