### PR TITLE
Support cog-runtime

### DIFF
--- a/script/test
+++ b/script/test
@@ -26,6 +26,7 @@ docker run --rm \
     --skip-cuda \
     --cog-versions \
     0.11.3 \
+    coglet==0.1.0-alpha1 \
     https://github.com/replicate/cog/archive/00b98bc90bb784102243b7aec41ad1cbffaefece.zip \
     --default-cog-version 0.11.3 \
     --write-node-feature-discovery-labels \
@@ -133,7 +134,7 @@ read -r -d '' SCRIPT << EOF || :
 import cog
 assert cog.__file__.startswith('/srv/r8/monobase/cog'), f'cog is not pre-installed: {cog.__file__}'
 assert cog.__version__ == '0.11.2.dev71+g00b98bc90b', f'cog.__version__ is not 0.11.2.dev71+g00b98bc90b: {cog.__version__}'
-print('PASS: Pre-installed cog==cog @ https://...')
+print('PASS: Pre-installed cog @ https://...')
 EOF
 docker run --rm \
     --volume "$PWD/src/monobase:/opt/r8/monobase" \
@@ -169,12 +170,48 @@ read -r -d '' SCRIPT << EOF || :
 import cog
 assert cog.__file__.startswith('/root/cog'), f'cog is not installed on the fly: {cog.__file__}'
 assert cog.__version__ == '0.11.4.dev77+g8ea4663247', f'cog.__version__ is not 0.11.4.dev77+g8ea4663247: {cog.__version__}'
-print('PASS: On-demand cog==cog @ https://...')
+print('PASS: On-demand cog @ https://...')
 EOF
 docker run --rm \
     --volume "$PWD/src/monobase:/opt/r8/monobase" \
     --volume "$PWD/build/monobase:/srv/r8/monobase" \
     --env R8_COG_VERSION=https://github.com/replicate/cog/archive/8ea466324738f3143954ec5be3211051659a20da.zip \
+    --env R8_CUDA_VERSION=12.4 \
+    --env R8_CUDNN_VERSION=9 \
+    --env R8_PYTHON_VERSION=3.12 \
+    --env R8_TORCH_VERSION=2.4.1 \
+    monobase:latest \
+    '/opt/r8/monobase/exec.sh' \
+    python -c "$SCRIPT"
+
+read -r -d '' SCRIPT << EOF || :
+import coglet
+assert coglet.__file__.startswith('/srv/r8/monobase/cog'), f'coglet is not pre-installed: {coglet.__file__}'
+assert coglet.__version__ == '0.1.0a1', f'coglet.__version__ is not 0.1.0a1: {coglet.__version__}'
+print('PASS: Pre-installed coglet==0.1.0-alpha1')
+EOF
+docker run --rm \
+    --volume "$PWD/src/monobase:/opt/r8/monobase" \
+    --volume "$PWD/build/monobase:/srv/r8/monobase" \
+    --env R8_COG_VERSION=coglet==0.1.0-alpha1 \
+    --env R8_CUDA_VERSION=12.4 \
+    --env R8_CUDNN_VERSION=9 \
+    --env R8_PYTHON_VERSION=3.12 \
+    --env R8_TORCH_VERSION=2.4.1 \
+    monobase:latest \
+    '/opt/r8/monobase/exec.sh' \
+    python -c "$SCRIPT"
+
+read -r -d '' SCRIPT << EOF || :
+import coglet
+assert coglet.__file__.startswith('/root/cog'), f'coglet is not installed on the fly: {coglet.__file__}'
+assert coglet.__version__ == '0.1.0a1', f'coglet.__version__ is not 0.1.0a1: {coglet.__version__}'
+print('PASS: On-demand coglet==0.1.0-alpha1')
+EOF
+docker run --rm \
+    --volume "$PWD/src/monobase:/opt/r8/monobase" \
+    --volume "$PWD/build/monobase:/srv/r8/monobase" \
+    --env R8_COG_VERSION=https://github.com/replicate/cog-runtime/releases/download/v0.1.0-alpha1/coglet-0.1.0a1-py3-none-any.whl \
     --env R8_CUDA_VERSION=12.4 \
     --env R8_CUDNN_VERSION=9 \
     --env R8_PYTHON_VERSION=3.12 \

--- a/uv.lock
+++ b/uv.lock
@@ -218,7 +218,7 @@ wheels = [
 
 [[package]]
 name = "monobase"
-version = "0.1.dev125+gfb146e4.d20241215"
+version = "0.1.dev135+g2d37e35.d20250106"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-api" },


### PR DESCRIPTION
`coglet` is a drop in replacement for vanilla cog. The wheel file contains Go `cog-server` binary and `cog.server.http` module wrapper.
To use `coglet` instead of `cog`, we specify `--cog-versions` & `R8_COG_VERSION` as one of:
* `https://github.com/replicate/cog-runtime/releases/download/v<version>/coglet-<version>-py3-none-any.whl`
* `coglet==<version>`