### PR TITLE
Fix OTEL dict attribute warning

### DIFF
--- a/src/monobase/build.py
+++ b/src/monobase/build.py
@@ -167,7 +167,7 @@ def build_generation(args: argparse.Namespace, mg: MonoGen) -> None:
     optimize_ld_cache(args, gdir, mg)
     optimize_rdfind(args, gdir, mg)
 
-    mark_done(gdir, kind='monogen', **mg.__dict__)
+    mark_done(gdir, kind='monogen', **mg.otel_attributes)
     log.info(f'Generation {mg.id} installed in {gdir}')
 
 


### PR DESCRIPTION
Seeing these warnings from OTEL:
```
{"logger": "opentelemetry.attributes", "timestamp": "2025-01-10T00:53:36.291879Z", "severity": "WARNING", "message": "Invalid type dict for attribute 'cuda' value. Expected one of ['bool', 'str', 'bytes', 'int', 'float'] or a sequence of those
types"}
{"logger": "opentelemetry.attributes", "timestamp": "2025-01-10T00:53:36.291982Z", "severity": "WARNING", "message": "Invalid type dict for attribute 'cudnn' value. Expected one of ['bool', 'str', 'bytes', 'int', 'float'] or a sequence of those
 types"}
{"logger": "opentelemetry.attributes", "timestamp": "2025-01-10T00:53:36.292018Z", "severity": "WARNING", "message": "Invalid type dict for attribute 'python' value. Expected one of ['bool', 'str', 'bytes', 'int', 'float'] or a sequence of thos
e types"}
```