### PR TITLE
Tweak APT layer

### DIFF
--- a/script/build-mini-image
+++ b/script/build-mini-image
@@ -7,6 +7,6 @@ set -euo pipefail
 cd "$(git rev-parse --show-toplevel)"
 
 # Run apt.sh to produce a tarball
-docker run --rm --volume "$PWD":/src monobase:mini /opt/r8/monobase/apt.sh /src/apt.tar.zst fzf protobuf-compiler ripgrep
+docker run --rm --volume "$PWD":/src monobase:latest /opt/r8/monobase/apt.sh /src/apt.tar.zst fzf protobuf-compiler ripgrep
 
 exec docker build --file mini.Dockerfile --tag monobase:mini --platform=linux/amd64 .

--- a/src/monobase/apt.sh
+++ b/src/monobase/apt.sh
@@ -12,12 +12,8 @@ fi
 tarball=$1
 shift
 
-# Disable post install clean so we can access downloaded .deb files
-mv /etc/apt/apt.conf.d/docker-clean{,.skip}
-
-# We need ar from binutils and compression codes used by various packages
 apt-get update
-apt-get install -y binutils bzip2 xz-utils zstd "$@"
+apt-get install --yes --download-only "$@"
 
 mkdir /tmp/apt-temp /tmp/apt-root
 
@@ -44,6 +40,5 @@ tar -cvf "$tarball" --zstd .
 
 rm -rf /tmp/apt-temp /tmp/apt-root
 
-# Clean up and restore conf
+# Clean up
 rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin
-mv /etc/apt/apt.conf.d/docker-clean{.skip,}


### PR DESCRIPTION
* Use monobase:latest to build apt tarball
* Compression codecs are already in monobase:latest
* Use --download-only and remove apt.conf.d hack
