### PR TITLE
Remove verbose output from tar monobase

### DIFF
--- a/src/monobase/tar.sh
+++ b/src/monobase/tar.sh
@@ -27,6 +27,6 @@ exec tar \
     --group=0 \
     --mode=go+u,go-w \
     --zstd \
-    -cvf "$tarball" \
+    -cf "$tarball" \
     -C "$root" \
     "$@"


### PR DESCRIPTION
* We do not need this noisiness in fast push