### PR TITLE
Expose monobase venv during user venv pip install

### DIFF
--- a/src/monobase/monogen.py
+++ b/src/monobase/monogen.py
@@ -22,9 +22,10 @@ class MonoGen:
 
 
 # uv venv --seed does not install deprecated setuptools or wheel for Python 3.12
+# Packaging is needed for flash-attn, etc.
 # Explicitly declare them here
 # Versions are not pinned and we will use whatever Torch index has
-SEED_PKGS = ['pip', 'setuptools', 'wheel']
+SEED_PKGS = ['pip', 'packaging', 'setuptools', 'wheel']
 
 TEST_MONOGENS: list[MonoGen] = [
     MonoGen(

--- a/uv.lock
+++ b/uv.lock
@@ -218,7 +218,6 @@ wheels = [
 
 [[package]]
 name = "monobase"
-version = "0.1.dev166+g8f72bfe.d20250128"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-api" },


### PR DESCRIPTION
Some packages like `flash-attn` needs access to `torch` and `nvcc` during
installation. Expose monobase venv and `CUDA_HOME` in those cases.
