### PR TITLE
Improve user layer build & test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,18 @@ jobs:
       - run: ./script/build-image
       - run: ./script/test-mini
 
+  test-user:
+    name: Test User
+    runs-on: ubuntu-latest-4-cores
+    env:
+      R8_CUDA_PREFIX: ${{ secrets.R8_CUDA_PREFIX }}
+      R8_CUDNN_PREFIX: ${{ secrets.R8_CUDNN_PREFIX }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+      - run: ./script/build-image
+      - run: ./script/test-user
+
   build-release:
     name: Build + release image
     needs:

--- a/script/latest_coglet.py
+++ b/script/latest_coglet.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+import json
+import re
+import urllib
+import urllib.parse
+import urllib.request
+
+
+def latest():
+    url = 'https://api.github.com/repos/replicate/cog-runtime/releases/latest'
+    content = urllib.request.urlopen(url).read()
+    blob = json.loads(content)
+    whl = blob['assets'][0]['browser_download_url']
+    m = re.match(r'.*/coglet-(?P<version>[^-]+)-.*\.whl', whl)
+    print(m.group('version'))
+
+
+if __name__ == '__main__':
+    latest()

--- a/script/test-mini
+++ b/script/test-mini
@@ -111,11 +111,12 @@ if [ "$fail" -gt 0 ]; then
     exit 1
 fi
 
+coglet_version="$(script/latest_coglet.py)"
 read -r -d '' SCRIPT << EOF || :
 import sys, coglet, torch
 assert sys.version.startswith('3.12.8'), f'sys.version is not 3.12.8: {sys.version}'
 assert coglet.__file__.startswith('/srv/r8/monobase/cog'), f'coglet is not pre-installed: {coglet.__file__}'
-assert coglet.__version__ == '0.1.0a2', f'coglet.__version__ is not 0.1.0a2: {coglet.__version__}'
+assert coglet.__version__ == '$coglet_version', f'coglet.__version__ is not $coglet_version: {coglet.__version__}'
 assert torch.__version__ == '2.4.1+cu124', f'torch.__version__ is not 2.4.1+cu124: {torch.__version__}'
 print('PASS: venv versions')
 EOF

--- a/script/test-mini
+++ b/script/test-mini
@@ -20,7 +20,6 @@ docker run --rm \
     --env R8_PYTHON_VERSION=3.12 \
     --env R8_TORCH_VERSION=2.4.1 \
     --env CI_SKIP_CUDA=1 \
-    --volume "$PWD/requirements-user.txt:/tmp/requirements-user.txt:ro" \
     --volume "$PWD/src/monobase:/opt/r8/monobase:ro" \
     --volume "$PWD/build/monobase:/srv/r8/monobase" \
     --volume "$PWD/build/cache:/var/cache/monobase" \

--- a/script/test-user
+++ b/script/test-user
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+
+# Build mini image for local development
+
+set -euo pipefail
+
+MONOBASE_PYTHON='3.13'
+
+cd "$(git rev-parse --show-toplevel)"
+
+# Build test requirements
+uv run --python "$MONOBASE_PYTHON" python -m monobase.update --environment test
+
+# Build test PREFIX
+mkdir -p build/monobase build/cache build/src
+docker run --rm \
+    --env R8_COG_VERSION=coglet \
+    --env R8_CUDA_VERSION=12.4 \
+    --env R8_CUDNN_VERSION=9 \
+    --env R8_PYTHON_VERSION=3.12 \
+    --env R8_TORCH_VERSION=2.4.1 \
+    --env CI_SKIP_CUDA=1 \
+    --volume "$PWD/requirements-user.txt:/tmp/requirements-user.txt:ro" \
+    --volume "$PWD/src/monobase:/opt/r8/monobase:ro" \
+    --volume "$PWD/build/monobase:/srv/r8/monobase" \
+    --volume "$PWD/build/cache:/var/cache/monobase" \
+    monobase:latest \
+    /opt/r8/monobase/run.sh \
+    monobase.build \
+    --environment test \
+    --mini \
+    "$@"
+
+test() {
+    package="$1"
+    version="$2"
+    requirements="$3"
+    tmp="$(mktemp -d -t monobase.XXXXXXXX)"
+    echo "$requirements" > "$tmp/requirements.txt"
+    mkdir "$tmp/root"
+
+    docker run --rm \
+        --env R8_COG_VERSION=coglet \
+        --env R8_CUDA_VERSION=12.4 \
+        --env R8_CUDNN_VERSION=9 \
+        --env R8_PYTHON_VERSION=3.12 \
+        --env R8_TORCH_VERSION=2.4.1 \
+        --env CI_SKIP_CUDA=1 \
+        --volume "$PWD/src/monobase:/opt/r8/monobase:ro" \
+        --volume "$PWD/build/monobase:/srv/r8/monobase" \
+        --volume "$PWD/build/src:/src:ro" \
+        --volume "$tmp/requirements.txt:/tmp/requirements.txt:ro" \
+        --volume "$tmp/root:/root" \
+        --workdir /src \
+        monobase:latest \
+        /opt/r8/monobase/run.sh \
+        monobase.user \
+        --requirements /tmp/requirements.txt \
+
+    read -r -d '' SCRIPT << EOF || :
+import $package
+assert $package.__version__ == '$version', f'$package.__version__ is not $version: {$package.__version__}'
+print('PASS: requirements $requirements')
+EOF
+
+    docker run --rm \
+        --volume "$PWD/src/monobase:/opt/r8/monobase:ro" \
+        --volume "$PWD/build/monobase:/srv/r8/monobase:ro" \
+        --volume "$tmp/root:/root" \
+        --env R8_CUDA_VERSION=12.4 \
+        --env R8_CUDNN_VERSION=9 \
+        --env R8_PYTHON_VERSION=3.12 \
+        --env R8_TORCH_VERSION=2.4.1 \
+        monobase:latest \
+        '/opt/r8/monobase/exec.sh' \
+        python -c "$SCRIPT"
+}
+
+# 2.28.1 (4d39457) is the latest available from Torch index
+test requests 2.28.1 'requests==2.28.1'
+
+# Wheel files
+test requests 2.28.1 'requests @ https://github.com/psf/requests/releases/download/v2.28.1/requests-2.28.1-py3-none-any.whl'
+test requests 2.28.1 'https://github.com/psf/requests/releases/download/v2.28.1/requests-2.28.1-py3-none-any.whl'
+
+# ZIP files
+test requests 2.28.1 'requests @ https://github.com/psf/requests/archive/4d394574f5555a8ddcc38f707e0c9f57f55d9a3b.zip'
+test requests 2.28.1 'https://github.com/psf/requests/archive/4d394574f5555a8ddcc38f707e0c9f57f55d9a3b.zip'
+
+# Github
+test requests 2.28.1 'git+https://github.com/psf/requests@v2.28.1'
+test requests 2.28.1 'git+https://github.com/psf/requests@4d394574f5555a8ddcc38f707e0c9f57f55d9a3b'
+
+# Local files
+rm -rf build/src/requests*
+curl -fsSL 'https://github.com/psf/requests/releases/download/v2.28.1/requests-2.28.1-py3-none-any.whl' -o build/src/requests-2.28.1-py3-none-any.whl
+test requests 2.28.1 './requests-2.28.1-py3-none-any.whl'
+curl -fsSL 'https://github.com/psf/requests/archive/4d394574f5555a8ddcc38f707e0c9f57f55d9a3b.zip' -o build/src/requests.zip
+test requests 2.28.1 './requests.zip'
+# FIXME: build fails due to read-only file system
+# git clone --depth 1 --branch v2.28.1 https://github.com/psf/requests.git build/src/requests.git
+# test requests 2.28.1 './requests.git'

--- a/src/monobase/activate.sh
+++ b/src/monobase/activate.sh
@@ -52,7 +52,7 @@ if [ -z "${R8_COG_VERSION:-}" ]; then
         return 1
     fi
     COG_VENV="$(readlink -f "$COG_PATH")"
-    R8_COG_VERSION="$(basename "$COG_VENV" | sed 's/cog\(.*\)-python.*/\1/')"
+    R8_COG_VERSION="$(basename "$COG_VENV" | sed 's/\(cog\(let\)\?\)\(.*\)-python.*/\1==\3/')"
     log_warning "R8_COG_VERSION not set, using default $R8_COG_VERSION"
 else
     case $R8_COG_VERSION in

--- a/src/monobase/update.py
+++ b/src/monobase/update.py
@@ -47,8 +47,9 @@ def update_generation(
         'venvs': venvs,
     }
     project_dir = pathlib.Path(__file__).absolute().parent.parent.parent
-    with open(os.path.join(project_dir, 'matrix.json'), 'w') as f:
-        json.dump(matrix, f, indent=2)
+    if args.environment == 'prod':
+        with open(os.path.join(project_dir, 'matrix.json'), 'w') as f:
+            json.dump(matrix, f, indent=2)
 
 
 def update(args: argparse.Namespace) -> None:

--- a/src/monobase/user.py
+++ b/src/monobase/user.py
@@ -117,8 +117,8 @@ def build_user_venv(args: argparse.Namespace) -> None:
             cmd, check=True, env=env, input=combined_req, capture_output=True, text=True
         )
     except subprocess.CalledProcessError as e:
-        log.error(e.stdout)
-        log.error(e.stderr)
+        print(e.stdout)
+        print(e.stderr)
         raise e
 
     user_req = proc.stdout

--- a/src/monobase/user.py
+++ b/src/monobase/user.py
@@ -160,7 +160,10 @@ def build_user_venv(args: argparse.Namespace) -> None:
             if mvs is not None:
                 log.warning(f'excluding {k} from user venv: mono=={mvs}, user=={uvs}')
                 continue
-            if type(uvs) is str:
+            if k == uvs and type(uvs) is str and os.path.exists(uvs):
+                # Local path, always include, even if it might conflict with monobase, e.g. ./torch-2.6.0.dev*.whl
+                print(k, file=f)
+            elif type(uvs) is str:
                 print(f'{k} @ {uvs}', file=f)
             else:
                 print(f'{k}=={uvs}', file=f)

--- a/src/monobase/util.py
+++ b/src/monobase/util.py
@@ -173,12 +173,11 @@ def parse_requirements(req: str) -> dict[str, str | Version]:
         if line == '' or line.startswith('#') or line.startswith('--'):
             continue
         if '==' in line:
-            parts = line.split('==')
+            parts = line.split('==', 1)
         elif '@' in line:
-            parts = line.split('@')
+            parts = line.split('@', 1)
         else:
             raise ValueError(f'invalid requirement: {line}')
-        assert len(parts) == 2, f'invalid requirement: {line}'
         vs = parts[1].strip()
         try:
             versions[parts[0].strip()] = Version.parse(vs)

--- a/src/monobase/util.py
+++ b/src/monobase/util.py
@@ -176,6 +176,10 @@ def parse_requirements(req: str) -> dict[str, str | Version]:
             parts = line.split('==', 1)
         elif '@' in line:
             parts = line.split('@', 1)
+        elif os.path.exists(line):
+            # Local file, version unknown, use exact path as version
+            p = os.path.abspath(line)
+            parts = [p, p]
         else:
             raise ValueError(f'invalid requirement: {line}')
         vs = parts[1].strip()


### PR DESCRIPTION
- **Only update matrix.json for prod environment**
- **Stop checking coglet version in mini test**
- **Remove unused requirements-user.txt from mini build**
- **Capture cog/coglet==latest/version in activate.sh**
- **Print uv compile error directly**
- **Limit split when parsing requirements**
- **Support local path in monobase.user requirements.txt**
- **Add test for user layer build**
