### PR TITLE
Include torch index in user layer pip install

### DIFF
--- a/src/monobase/user.py
+++ b/src/monobase/user.py
@@ -168,6 +168,7 @@ def build_user_venv(args: argparse.Namespace) -> None:
             else:
                 print(f'{k}=={uvs}', file=f)
     cmd = [uv, 'pip', 'install', '--no-deps', '--requirement', user_req_path]
+    cmd += index_args(torch_version, cuda_version)
     env.update(uv_install_env)
     subprocess.run(cmd, check=True, env=env)
 


### PR DESCRIPTION
* We always install a frozen requirements from `uv pip compile` with
  Torch index, which might include packages not in public PyPI, e.g.
  `torch*+cuXXX`
* We need to include the same index for `uv pip install`
* This should not regress as we only installed packages available in
  both PyPI and Torch index before
