### PR TITLE
Add .venv/bin to PATH in run.sh

### DIFF
--- a/src/monobase/run.sh
+++ b/src/monobase/run.sh
@@ -49,4 +49,5 @@ if ! [ -d /var/tmp/.venv ]; then
 fi
 
 log "Running $module..."
-exec /var/tmp/.venv/bin/python -m "$module" "$@"
+export PATH="$PATH:/var/tmp/.venv/bin"
+exec /var/tmp/.venv/bin/python3 -m "$module" "$@"


### PR DESCRIPTION
run.sh runs the monobase scripts which might call other Python scripts
in sub-shells, e.g. pget.py. Append .venv/bin, i.e. the same one running
monobase, to PATH for these scripts.
