### PR TITLE
Add —refresh-package to uv pip install of cog

### DIFF
--- a/src/monobase/cog.py
+++ b/src/monobase/cog.py
@@ -120,7 +120,7 @@ def install_cog(
     env = os.environ.copy()
     env['VIRTUAL_ENV'] = vdir
 
-    cmd = [uv, 'pip', 'install', '--compile-bytecode', spec] + extra_packages
+    cmd = [uv, 'pip', 'install', '--refresh-package', '--compile-bytecode', spec] + extra_packages
     subprocess.run(cmd, check=True, env=env)
 
     if is_default:

--- a/src/monobase/cog.py
+++ b/src/monobase/cog.py
@@ -124,7 +124,7 @@ def install_cog(
         uv,
         'pip',
         'install',
-        '--refresh-package',
+        '--no-cache',
         '--compile-bytecode',
         spec,
     ] + extra_packages

--- a/src/monobase/cog.py
+++ b/src/monobase/cog.py
@@ -120,7 +120,14 @@ def install_cog(
     env = os.environ.copy()
     env['VIRTUAL_ENV'] = vdir
 
-    cmd = [uv, 'pip', 'install', '--refresh-package', '--compile-bytecode', spec] + extra_packages
+    cmd = [
+        uv,
+        'pip',
+        'install',
+        '--refresh-package',
+        '--compile-bytecode',
+        spec,
+    ] + extra_packages
     subprocess.run(cmd, check=True, env=env)
 
     if is_default:


### PR DESCRIPTION
* To potentially fix the issue of: No such file or directory (os error 2)
* Should make sure all the local directories exist before utilising the cache
* This will only be for cog/hf-transfer so should be light