### PR TITLE
Allow more flexibility in user venv build

### DIFF
--- a/script/test-user
+++ b/script/test-user
@@ -34,8 +34,10 @@ test() {
     package="$1"
     version="$2"
     requirements="$3"
+    override="${4:-}"
     tmp="$(mktemp -d -t monobase.XXXXXXXX)"
     echo "$requirements" > "$tmp/requirements.txt"
+    echo "$override" > "$tmp/override.txt"
     mkdir "$tmp/root"
 
     docker run --rm \
@@ -49,12 +51,14 @@ test() {
         --volume "$PWD/build/monobase:/srv/r8/monobase" \
         --volume "$PWD/build/src:/src:ro" \
         --volume "$tmp/requirements.txt:/tmp/requirements.txt:ro" \
+        --volume "$tmp/override.txt:/tmp/override.txt:ro" \
         --volume "$tmp/root:/root" \
         --workdir /src \
         monobase:latest \
         /opt/r8/monobase/run.sh \
         monobase.user \
         --requirements /tmp/requirements.txt \
+        --override /tmp/override.txt
 
     read -r -d '' SCRIPT << EOF || :
 import $package
@@ -77,6 +81,9 @@ EOF
 
 # 2.28.1 (4d39457) is the latest available from Torch index
 test requests 2.28.1 'requests==2.28.1'
+
+# Override
+test requests 2.32.3 'requests<=2.28.1' 'requests==2.32.3'
 
 # Wheel files
 test requests 2.28.1 'requests @ https://github.com/psf/requests/releases/download/v2.28.1/requests-2.28.1-py3-none-any.whl'

--- a/src/monobase/user.py
+++ b/src/monobase/user.py
@@ -27,6 +27,11 @@ parser.add_argument(
     metavar='FILE',
     help='Python requirements.txt for user layer',
 )
+parser.add_argument(
+    '--override',
+    metavar='FILE',
+    help='Python requirements.txt for overriding versions',
+)
 
 
 def freeze(uv: str, vdir: str) -> str:
@@ -108,6 +113,9 @@ def build_user_venv(args: argparse.Namespace) -> None:
 
     log.info(f'Compiling user requirements {args.requirements}...')
     cmd = [uv, 'pip', 'compile']
+    # Override version conflicts, e.g.
+    if args.override is not None:
+        cmd = cmd + ['--override', args.override]
     # PyPI is inconsistent with Torch index and may include nvidia packages for CPU torch
     # Use the same Torch index instead
     cmd = cmd + index_args(torch_version, cuda_version, True) + ['-']

--- a/src/monobase/user.py
+++ b/src/monobase/user.py
@@ -110,7 +110,7 @@ def build_user_venv(args: argparse.Namespace) -> None:
     cmd = [uv, 'pip', 'compile']
     # PyPI is inconsistent with Torch index and may include nvidia packages for CPU torch
     # Use the same Torch index instead
-    cmd = cmd + index_args(torch_version, cuda_version) + ['-']
+    cmd = cmd + index_args(torch_version, cuda_version, True) + ['-']
     env['VIRTUAL_ENV'] = udir
     try:
         proc = subprocess.run(
@@ -172,7 +172,7 @@ def build_user_venv(args: argparse.Namespace) -> None:
             else:
                 print(f'{k}=={uvs}', file=f)
     cmd = [uv, 'pip', 'install', '--no-deps', '--requirement', user_req_path]
-    cmd += index_args(torch_version, cuda_version)
+    cmd += index_args(torch_version, cuda_version, True)
     env.update(uv_install_env)
     subprocess.run(cmd, check=True, env=env)
 


### PR DESCRIPTION
- **Use unsafe-first-match index-strategy for user venv**
- **Support uv pip compile --override**

`unsafe-first-match` so that we are not constrained by older packages in pytorch.org index. We use pre-frozen Torch requirements and exclude them from user venv anyway.

`--override` can be used to bypass irreconcilable conflicts.

For conflicts against base venv, e.g. `pyreft` wants `numpy==1.26.4` but base venv has `numpy==1.26.3`, we must pin it to the latter as base venv has higher precedence.
```
# override.txt
numpy==1.26.3
```

For conflicts in user's `requirements.txt`, e.g. user wants package `A` & `B` that want `C==1.0.0` vs `C==1.1.0`, we have to pick one and verify that it works with both.