### PR TITLE
Consolidate env vars in activate.sh

### DIFF
--- a/src/monobase/activate.sh
+++ b/src/monobase/activate.sh
@@ -105,16 +105,17 @@ fi
 MONOBASE_PATH="$MONOBASE_PREFIX/monobase/$(printf 'g%05d' "$MONOBASE_GEN_ID")"
 
 if [ -n "${R8_CUDA_VERSION:-}" ] && [ -n "${R8_CUDNN_VERSION:-}" ]; then
-    CUDA_PATH="$MONOBASE_PATH/cuda$R8_CUDA_VERSION"
-    export LIBRARY_PATH="$CUDA_PATH/lib64/stubs"
-    PATH="$CUDA_PATH/bin${PATH:+:${PATH}}"
+    # flash-attn, etc. needs CUDA_HOME for compilation
+    export CUDA_HOME="$MONOBASE_PATH/cuda$R8_CUDA_VERSION"
+    export LIBRARY_PATH="$CUDA_HOME/lib64/stubs"
+    PATH="$CUDA_HOME/bin${PATH:+:${PATH}}"
 
     CUDA_MAJOR="$(echo "$R8_CUDA_VERSION" | sed 's/\..\+//')"
-    CUDNN_PATH="$MONOBASE_PATH/cudnn$R8_CUDNN_VERSION-cuda${CUDA_MAJOR}"
+    CUDNN_HOME="$MONOBASE_PATH/cudnn$R8_CUDNN_VERSION-cuda${CUDA_MAJOR}"
 
     # NVIDIA Container Toolkit mounts drivers here
     NCT_PATH=/usr/lib/x86_64-linux-gnu
-    LD_LIBRARY_PATH="$NCT_PATH:$CUDA_PATH/lib64:$CUDNN_PATH/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+    LD_LIBRARY_PATH="$NCT_PATH:$CUDA_HOME/lib64:$CUDNN_HOME/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
 
     LD_CACHE_PATH="$MONOBASE_PATH/ld.so.cache.d/cuda$R8_CUDA_VERSION-cudnn$R8_CUDNN_VERSION-python$R8_PYTHON_VERSION"
     cp -f "$LD_CACHE_PATH" /etc/ld.so.cache

--- a/src/monobase/run.sh
+++ b/src/monobase/run.sh
@@ -56,7 +56,11 @@ if ! [ -d /var/tmp/.venv ]; then
 fi
 
 if [ "$module" == monobase.user ]; then
+    # shellcheck disable=SC1091
     source /opt/r8/monobase/activate.sh
+    # PYTHONPATH of Cog + monobase + user venvs after activation
+    # Save it before it's overriden below before running monobase.$module
+    export R8_PYTHONPATH="$PYTHONPATH"
 fi
 
 log "Running $module..."
@@ -64,5 +68,6 @@ export PATH="$PATH:/var/tmp/.venv/bin"
 
 # We mount $PWD/src/monobase:/opt/r8/monobase for local testing
 # Layer it on top of venv, i.e. code from wheel file
+# monobase.user restores it with R8_PYTHONPATH when working with user venv
 export PYTHONPATH="/opt/r8:/var/tmp/.venv/lib/python$MONOBASE_PYTHON_VERSION/site-packages"
 exec /var/tmp/.venv/bin/python3 -m "$module" "$@"


### PR DESCRIPTION
Set `CUDA_HOME` and `PYTHONPATH` in `activate.sh` which is sourced before running `monobase.user`.

However, we use a temp `/var/tmp.venv` & `PYTHONPATH` to run `monobase.*`. Therefore we need to save the actual `PYTHONPATH` of runtime environment in `R8_PYTHONPATH` and restore it in `monobase.user`.