### PR TITLE
Patch gen 18: add cython

### DIFF
--- a/src/monobase/requirements/g00018/python3.10-torch2.0.0-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.0.0-cpu.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cpu
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -35,7 +37,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.10-torch2.0.0-cu117.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.0.0-cu117.txt
@@ -12,6 +12,8 @@ charset-normalizer==2.1.1
 cmake==3.25.0
     # via triton
     # from https://download.pytorch.org/whl/cu117
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -49,7 +51,7 @@ nvidia-cuda-nvrtc-cu11==11.8.89
     # from https://pypi.org/simple
 nvidia-cuda-runtime-cu11==11.8.89
     # from https://pypi.org/simple
-nvidia-cudnn-cu11==9.8.0.87
+nvidia-cudnn-cu11==9.9.0.52
     # from https://pypi.org/simple
 nvidia-cufft-cu11==10.9.0.58
     # from https://pypi.org/simple
@@ -68,7 +70,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu117
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.10-torch2.0.0-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.0.0-cu118.txt
@@ -12,6 +12,8 @@ charset-normalizer==2.1.1
 cmake==3.25.0
     # via triton
     # from https://download.pytorch.org/whl/cu118
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -68,7 +70,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.10-torch2.0.1-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.0.1-cpu.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cpu
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -35,7 +37,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.10-torch2.0.1-cu117.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.0.1-cu117.txt
@@ -12,6 +12,8 @@ charset-normalizer==2.1.1
 cmake==3.25.0
     # via triton
     # from https://download.pytorch.org/whl/cu117
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -49,7 +51,7 @@ nvidia-cuda-nvrtc-cu11==11.8.89
     # from https://pypi.org/simple
 nvidia-cuda-runtime-cu11==11.8.89
     # from https://pypi.org/simple
-nvidia-cudnn-cu11==9.8.0.87
+nvidia-cudnn-cu11==9.9.0.52
     # from https://pypi.org/simple
 nvidia-cufft-cu11==10.9.0.58
     # from https://pypi.org/simple
@@ -68,7 +70,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu117
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.10-torch2.0.1-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.0.1-cu118.txt
@@ -12,6 +12,8 @@ charset-normalizer==2.1.1
 cmake==3.25.0
     # via triton
     # from https://download.pytorch.org/whl/cu118
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -68,7 +70,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.10-torch2.1.0-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.1.0-cpu.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cpu
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -38,7 +40,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.10-torch2.1.0-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.1.0-cu118.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cu118
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -65,7 +67,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.10-torch2.1.0-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.1.0-cu121.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cu121
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -71,7 +73,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.10-torch2.1.1-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.1.1-cpu.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cpu
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -38,7 +40,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.10-torch2.1.1-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.1.1-cu118.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cu118
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -65,7 +67,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.10-torch2.1.1-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.1.1-cu121.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cu121
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -71,7 +73,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.10-torch2.1.2-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.1.2-cpu.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cpu
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -38,7 +40,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.10-torch2.1.2-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.1.2-cu118.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cu118
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -65,7 +67,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.10-torch2.1.2-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.1.2-cu121.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cu121
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -71,7 +73,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.10-torch2.2.0-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.2.0-cpu.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cpu
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -38,7 +40,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.10-torch2.2.0-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.2.0-cu118.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cu118
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -76,7 +78,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.10-torch2.2.0-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.2.0-cu121.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cu121
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -83,7 +85,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.10-torch2.2.1-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.2.1-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.10-torch2.2.1-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.2.1-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -67,7 +69,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu118

--- a/src/monobase/requirements/g00018/python3.10-torch2.2.1-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.2.1-cu121.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -74,7 +76,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu121

--- a/src/monobase/requirements/g00018/python3.10-torch2.2.2-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.2.2-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.10-torch2.2.2-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.2.2-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -67,7 +69,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu118

--- a/src/monobase/requirements/g00018/python3.10-torch2.2.2-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.2.2-cu121.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -74,7 +76,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu121

--- a/src/monobase/requirements/g00018/python3.10-torch2.3.0-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.3.0-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.10-torch2.3.0-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.3.0-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -67,7 +69,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu118

--- a/src/monobase/requirements/g00018/python3.10-torch2.3.0-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.3.0-cu121.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -74,7 +76,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu121

--- a/src/monobase/requirements/g00018/python3.10-torch2.3.1-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.3.1-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.10-torch2.3.1-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.3.1-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -67,7 +69,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu118

--- a/src/monobase/requirements/g00018/python3.10-torch2.3.1-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.3.1-cu121.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -74,7 +76,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu121

--- a/src/monobase/requirements/g00018/python3.10-torch2.4.0-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.4.0-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.10-torch2.4.0-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.4.0-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -67,7 +69,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu118

--- a/src/monobase/requirements/g00018/python3.10-torch2.4.0-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.4.0-cu121.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -74,7 +76,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu121

--- a/src/monobase/requirements/g00018/python3.10-torch2.4.0-cu124.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.4.0-cu124.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu124
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -75,7 +77,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu124
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu124

--- a/src/monobase/requirements/g00018/python3.10-torch2.4.1-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.4.1-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.10-torch2.4.1-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.4.1-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -67,7 +69,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu118

--- a/src/monobase/requirements/g00018/python3.10-torch2.4.1-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.4.1-cu121.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -74,7 +76,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu121

--- a/src/monobase/requirements/g00018/python3.10-torch2.4.1-cu124.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.4.1-cu124.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu124
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -75,7 +77,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu124
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu124

--- a/src/monobase/requirements/g00018/python3.10-torch2.5.0-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.5.0-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.10-torch2.5.0-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.5.0-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -67,7 +69,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu118

--- a/src/monobase/requirements/g00018/python3.10-torch2.5.0-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.5.0-cu121.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -74,7 +76,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu121

--- a/src/monobase/requirements/g00018/python3.10-torch2.5.0-cu124.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.5.0-cu124.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu124
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -75,7 +77,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu124
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu124

--- a/src/monobase/requirements/g00018/python3.10-torch2.5.1-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.5.1-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.10-torch2.5.1-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.5.1-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -67,7 +69,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu118

--- a/src/monobase/requirements/g00018/python3.10-torch2.5.1-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.5.1-cu121.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -74,7 +76,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu121

--- a/src/monobase/requirements/g00018/python3.10-torch2.5.1-cu124.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.5.1-cu124.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu124
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -75,7 +77,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu124
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu124

--- a/src/monobase/requirements/g00018/python3.10-torch2.6.0-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.6.0-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.10-torch2.6.0-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.6.0-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cu118
@@ -65,7 +67,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu118

--- a/src/monobase/requirements/g00018/python3.10-torch2.6.0-cu124.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.6.0-cu124.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu124
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cu124
@@ -76,7 +78,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu124
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu124

--- a/src/monobase/requirements/g00018/python3.10-torch2.6.0-cu126.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.6.0-cu126.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu126
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cu126
@@ -77,7 +79,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu126
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu126

--- a/src/monobase/requirements/g00018/python3.10-torch2.7.0-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.7.0-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.10-torch2.7.0-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.7.0-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cu118
@@ -65,7 +67,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via triton

--- a/src/monobase/requirements/g00018/python3.10-torch2.7.0-cu126.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.7.0-cu126.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu126
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cu126
@@ -80,7 +82,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu126
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via triton

--- a/src/monobase/requirements/g00018/python3.10-torch2.7.0-cu128.txt
+++ b/src/monobase/requirements/g00018/python3.10-torch2.7.0-cu128.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cu128
@@ -80,7 +82,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu128
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via triton

--- a/src/monobase/requirements/g00018/python3.11-torch2.0.0-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.0.0-cpu.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cpu
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -35,7 +37,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.11-torch2.0.0-cu117.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.0.0-cu117.txt
@@ -12,6 +12,8 @@ charset-normalizer==2.1.1
 cmake==3.25.0
     # via triton
     # from https://download.pytorch.org/whl/cu117
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -49,7 +51,7 @@ nvidia-cuda-nvrtc-cu11==11.8.89
     # from https://pypi.org/simple
 nvidia-cuda-runtime-cu11==11.8.89
     # from https://pypi.org/simple
-nvidia-cudnn-cu11==9.8.0.87
+nvidia-cudnn-cu11==9.9.0.52
     # from https://pypi.org/simple
 nvidia-cufft-cu11==10.9.0.58
     # from https://pypi.org/simple
@@ -68,7 +70,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu117
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.11-torch2.0.0-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.0.0-cu118.txt
@@ -12,6 +12,8 @@ charset-normalizer==2.1.1
 cmake==3.25.0
     # via triton
     # from https://download.pytorch.org/whl/cu118
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -68,7 +70,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.11-torch2.0.1-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.0.1-cpu.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cpu
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -35,7 +37,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.11-torch2.0.1-cu117.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.0.1-cu117.txt
@@ -12,6 +12,8 @@ charset-normalizer==2.1.1
 cmake==3.25.0
     # via triton
     # from https://download.pytorch.org/whl/cu117
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -49,7 +51,7 @@ nvidia-cuda-nvrtc-cu11==11.8.89
     # from https://pypi.org/simple
 nvidia-cuda-runtime-cu11==11.8.89
     # from https://pypi.org/simple
-nvidia-cudnn-cu11==9.8.0.87
+nvidia-cudnn-cu11==9.9.0.52
     # from https://pypi.org/simple
 nvidia-cufft-cu11==10.9.0.58
     # from https://pypi.org/simple
@@ -68,7 +70,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu117
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.11-torch2.0.1-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.0.1-cu118.txt
@@ -12,6 +12,8 @@ charset-normalizer==2.1.1
 cmake==3.25.0
     # via triton
     # from https://download.pytorch.org/whl/cu118
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -68,7 +70,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.11-torch2.1.0-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.1.0-cpu.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cpu
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -38,7 +40,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.11-torch2.1.0-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.1.0-cu118.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cu118
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -65,7 +67,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.11-torch2.1.0-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.1.0-cu121.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cu121
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -71,7 +73,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.11-torch2.1.1-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.1.1-cpu.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cpu
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -38,7 +40,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.11-torch2.1.1-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.1.1-cu118.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cu118
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -65,7 +67,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.11-torch2.1.1-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.1.1-cu121.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cu121
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -71,7 +73,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.11-torch2.1.2-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.1.2-cpu.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cpu
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -38,7 +40,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.11-torch2.1.2-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.1.2-cu118.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cu118
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -65,7 +67,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.11-torch2.1.2-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.1.2-cu121.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cu121
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -71,7 +73,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.11-torch2.2.0-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.2.0-cpu.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cpu
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -38,7 +40,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.11-torch2.2.0-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.2.0-cu118.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cu118
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -76,7 +78,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.11-torch2.2.0-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.2.0-cu121.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cu121
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -83,7 +85,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.11-torch2.2.1-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.2.1-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.11-torch2.2.1-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.2.1-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -67,7 +69,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu118

--- a/src/monobase/requirements/g00018/python3.11-torch2.2.1-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.2.1-cu121.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -74,7 +76,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu121

--- a/src/monobase/requirements/g00018/python3.11-torch2.2.2-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.2.2-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.11-torch2.2.2-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.2.2-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -67,7 +69,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu118

--- a/src/monobase/requirements/g00018/python3.11-torch2.2.2-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.2.2-cu121.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -74,7 +76,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu121

--- a/src/monobase/requirements/g00018/python3.11-torch2.3.0-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.3.0-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.11-torch2.3.0-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.3.0-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -67,7 +69,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu118

--- a/src/monobase/requirements/g00018/python3.11-torch2.3.0-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.3.0-cu121.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -74,7 +76,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu121

--- a/src/monobase/requirements/g00018/python3.11-torch2.3.1-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.3.1-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.11-torch2.3.1-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.3.1-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -67,7 +69,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu118

--- a/src/monobase/requirements/g00018/python3.11-torch2.3.1-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.3.1-cu121.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -74,7 +76,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu121

--- a/src/monobase/requirements/g00018/python3.11-torch2.4.0-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.4.0-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.11-torch2.4.0-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.4.0-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -67,7 +69,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu118

--- a/src/monobase/requirements/g00018/python3.11-torch2.4.0-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.4.0-cu121.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -74,7 +76,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu121

--- a/src/monobase/requirements/g00018/python3.11-torch2.4.0-cu124.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.4.0-cu124.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu124
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -75,7 +77,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu124
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu124

--- a/src/monobase/requirements/g00018/python3.11-torch2.4.1-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.4.1-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.11-torch2.4.1-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.4.1-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -67,7 +69,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu118

--- a/src/monobase/requirements/g00018/python3.11-torch2.4.1-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.4.1-cu121.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -74,7 +76,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu121

--- a/src/monobase/requirements/g00018/python3.11-torch2.4.1-cu124.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.4.1-cu124.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu124
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -75,7 +77,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu124
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu124

--- a/src/monobase/requirements/g00018/python3.11-torch2.5.0-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.5.0-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.11-torch2.5.0-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.5.0-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -67,7 +69,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu118

--- a/src/monobase/requirements/g00018/python3.11-torch2.5.0-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.5.0-cu121.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -74,7 +76,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu121

--- a/src/monobase/requirements/g00018/python3.11-torch2.5.0-cu124.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.5.0-cu124.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu124
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -75,7 +77,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu124
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu124

--- a/src/monobase/requirements/g00018/python3.11-torch2.5.1-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.5.1-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.11-torch2.5.1-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.5.1-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -67,7 +69,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu118

--- a/src/monobase/requirements/g00018/python3.11-torch2.5.1-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.5.1-cu121.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -74,7 +76,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu121

--- a/src/monobase/requirements/g00018/python3.11-torch2.5.1-cu124.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.5.1-cu124.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu124
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -75,7 +77,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu124
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu124

--- a/src/monobase/requirements/g00018/python3.11-torch2.6.0-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.6.0-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.11-torch2.6.0-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.6.0-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cu118
@@ -65,7 +67,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu118

--- a/src/monobase/requirements/g00018/python3.11-torch2.6.0-cu124.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.6.0-cu124.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu124
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cu124
@@ -76,7 +78,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu124
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu124

--- a/src/monobase/requirements/g00018/python3.11-torch2.6.0-cu126.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.6.0-cu126.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu126
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cu126
@@ -77,7 +79,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu126
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu126

--- a/src/monobase/requirements/g00018/python3.11-torch2.7.0-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.7.0-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.11-torch2.7.0-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.7.0-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cu118
@@ -65,7 +67,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via triton

--- a/src/monobase/requirements/g00018/python3.11-torch2.7.0-cu126.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.7.0-cu126.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu126
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cu126
@@ -80,7 +82,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu126
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via triton

--- a/src/monobase/requirements/g00018/python3.11-torch2.7.0-cu128.txt
+++ b/src/monobase/requirements/g00018/python3.11-torch2.7.0-cu128.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cu128
@@ -80,7 +82,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu128
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via triton

--- a/src/monobase/requirements/g00018/python3.12-torch2.4.0-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.12-torch2.4.0-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via torch

--- a/src/monobase/requirements/g00018/python3.12-torch2.4.0-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.12-torch2.4.0-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -67,7 +69,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via torch

--- a/src/monobase/requirements/g00018/python3.12-torch2.4.0-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.12-torch2.4.0-cu121.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -74,7 +76,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via torch

--- a/src/monobase/requirements/g00018/python3.12-torch2.4.0-cu124.txt
+++ b/src/monobase/requirements/g00018/python3.12-torch2.4.0-cu124.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu124
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -75,7 +77,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu124
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via torch

--- a/src/monobase/requirements/g00018/python3.12-torch2.4.1-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.12-torch2.4.1-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via torch

--- a/src/monobase/requirements/g00018/python3.12-torch2.4.1-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.12-torch2.4.1-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -67,7 +69,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via torch

--- a/src/monobase/requirements/g00018/python3.12-torch2.4.1-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.12-torch2.4.1-cu121.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -74,7 +76,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via torch

--- a/src/monobase/requirements/g00018/python3.12-torch2.4.1-cu124.txt
+++ b/src/monobase/requirements/g00018/python3.12-torch2.4.1-cu124.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu124
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -75,7 +77,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu124
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via torch

--- a/src/monobase/requirements/g00018/python3.12-torch2.5.0-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.12-torch2.5.0-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via torch

--- a/src/monobase/requirements/g00018/python3.12-torch2.5.0-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.12-torch2.5.0-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -67,7 +69,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via torch

--- a/src/monobase/requirements/g00018/python3.12-torch2.5.0-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.12-torch2.5.0-cu121.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -74,7 +76,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via torch

--- a/src/monobase/requirements/g00018/python3.12-torch2.5.0-cu124.txt
+++ b/src/monobase/requirements/g00018/python3.12-torch2.5.0-cu124.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu124
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -75,7 +77,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu124
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via torch

--- a/src/monobase/requirements/g00018/python3.12-torch2.5.1-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.12-torch2.5.1-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via torch

--- a/src/monobase/requirements/g00018/python3.12-torch2.5.1-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.12-torch2.5.1-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -67,7 +69,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via torch

--- a/src/monobase/requirements/g00018/python3.12-torch2.5.1-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.12-torch2.5.1-cu121.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -74,7 +76,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via torch

--- a/src/monobase/requirements/g00018/python3.12-torch2.5.1-cu124.txt
+++ b/src/monobase/requirements/g00018/python3.12-torch2.5.1-cu124.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu124
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -75,7 +77,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu124
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via torch

--- a/src/monobase/requirements/g00018/python3.12-torch2.6.0-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.12-torch2.6.0-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via torch

--- a/src/monobase/requirements/g00018/python3.12-torch2.6.0-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.12-torch2.6.0-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cu118
@@ -65,7 +67,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via torch

--- a/src/monobase/requirements/g00018/python3.12-torch2.6.0-cu124.txt
+++ b/src/monobase/requirements/g00018/python3.12-torch2.6.0-cu124.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu124
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cu124
@@ -76,7 +78,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu124
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via torch

--- a/src/monobase/requirements/g00018/python3.12-torch2.6.0-cu126.txt
+++ b/src/monobase/requirements/g00018/python3.12-torch2.6.0-cu126.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu126
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cu126
@@ -77,7 +79,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu126
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via torch

--- a/src/monobase/requirements/g00018/python3.12-torch2.7.0-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.12-torch2.7.0-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via torch

--- a/src/monobase/requirements/g00018/python3.12-torch2.7.0-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.12-torch2.7.0-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cu118
@@ -65,7 +67,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via

--- a/src/monobase/requirements/g00018/python3.12-torch2.7.0-cu126.txt
+++ b/src/monobase/requirements/g00018/python3.12-torch2.7.0-cu126.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu126
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cu126
@@ -80,7 +82,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu126
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via

--- a/src/monobase/requirements/g00018/python3.12-torch2.7.0-cu128.txt
+++ b/src/monobase/requirements/g00018/python3.12-torch2.7.0-cu128.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cu128
@@ -80,7 +82,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu128
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via

--- a/src/monobase/requirements/g00018/python3.13-torch2.6.0-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.13-torch2.6.0-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via torch

--- a/src/monobase/requirements/g00018/python3.13-torch2.6.0-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.13-torch2.6.0-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cu118
@@ -65,7 +67,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via torch

--- a/src/monobase/requirements/g00018/python3.13-torch2.6.0-cu124.txt
+++ b/src/monobase/requirements/g00018/python3.13-torch2.6.0-cu124.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu124
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cu124
@@ -76,7 +78,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu124
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via torch

--- a/src/monobase/requirements/g00018/python3.13-torch2.6.0-cu126.txt
+++ b/src/monobase/requirements/g00018/python3.13-torch2.6.0-cu126.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu126
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cu126
@@ -77,7 +79,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu126
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via torch

--- a/src/monobase/requirements/g00018/python3.13-torch2.7.0-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.13-torch2.7.0-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via torch

--- a/src/monobase/requirements/g00018/python3.13-torch2.7.0-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.13-torch2.7.0-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cu118
@@ -65,7 +67,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via

--- a/src/monobase/requirements/g00018/python3.13-torch2.7.0-cu126.txt
+++ b/src/monobase/requirements/g00018/python3.13-torch2.7.0-cu126.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu126
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cu126
@@ -80,7 +82,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu126
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via

--- a/src/monobase/requirements/g00018/python3.13-torch2.7.0-cu128.txt
+++ b/src/monobase/requirements/g00018/python3.13-torch2.7.0-cu128.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cu128
@@ -80,7 +82,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu128
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via

--- a/src/monobase/requirements/g00018/python3.8-torch2.0.0-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.0.0-cpu.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cpu
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.8-torch2.0.0-cu117.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.0.0-cu117.txt
@@ -12,6 +12,8 @@ charset-normalizer==2.1.1
 cmake==3.25.0
     # via triton
     # from https://download.pytorch.org/whl/cu117
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -49,7 +51,7 @@ nvidia-cuda-nvrtc-cu11==11.8.89
     # from https://pypi.org/simple
 nvidia-cuda-runtime-cu11==11.8.89
     # from https://pypi.org/simple
-nvidia-cudnn-cu11==9.8.0.87
+nvidia-cudnn-cu11==9.9.0.52
     # from https://pypi.org/simple
 nvidia-cufft-cu11==10.9.0.58
     # from https://pypi.org/simple

--- a/src/monobase/requirements/g00018/python3.8-torch2.0.0-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.0.0-cu118.txt
@@ -12,6 +12,8 @@ charset-normalizer==2.1.1
 cmake==3.25.0
     # via triton
     # from https://download.pytorch.org/whl/cu118
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch

--- a/src/monobase/requirements/g00018/python3.8-torch2.0.1-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.0.1-cpu.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cpu
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.8-torch2.0.1-cu117.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.0.1-cu117.txt
@@ -12,6 +12,8 @@ charset-normalizer==2.1.1
 cmake==3.25.0
     # via triton
     # from https://download.pytorch.org/whl/cu117
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -49,7 +51,7 @@ nvidia-cuda-nvrtc-cu11==11.8.89
     # from https://pypi.org/simple
 nvidia-cuda-runtime-cu11==11.8.89
     # from https://pypi.org/simple
-nvidia-cudnn-cu11==9.8.0.87
+nvidia-cudnn-cu11==9.9.0.52
     # from https://pypi.org/simple
 nvidia-cufft-cu11==10.9.0.58
     # from https://pypi.org/simple

--- a/src/monobase/requirements/g00018/python3.8-torch2.0.1-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.0.1-cu118.txt
@@ -12,6 +12,8 @@ charset-normalizer==2.1.1
 cmake==3.25.0
     # via triton
     # from https://download.pytorch.org/whl/cu118
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch

--- a/src/monobase/requirements/g00018/python3.8-torch2.1.0-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.1.0-cpu.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cpu
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.8-torch2.1.0-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.1.0-cu118.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cu118
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch

--- a/src/monobase/requirements/g00018/python3.8-torch2.1.0-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.1.0-cu121.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cu121
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch

--- a/src/monobase/requirements/g00018/python3.8-torch2.1.1-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.1.1-cpu.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cpu
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.8-torch2.1.1-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.1.1-cu118.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cu118
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch

--- a/src/monobase/requirements/g00018/python3.8-torch2.1.1-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.1.1-cu121.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cu121
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch

--- a/src/monobase/requirements/g00018/python3.8-torch2.1.2-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.1.2-cpu.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cpu
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.8-torch2.1.2-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.1.2-cu118.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cu118
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch

--- a/src/monobase/requirements/g00018/python3.8-torch2.1.2-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.1.2-cu121.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cu121
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch

--- a/src/monobase/requirements/g00018/python3.8-torch2.2.0-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.2.0-cpu.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cpu
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.8-torch2.2.0-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.2.0-cu118.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cu118
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch

--- a/src/monobase/requirements/g00018/python3.8-torch2.2.0-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.2.0-cu121.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cu121
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch

--- a/src/monobase/requirements/g00018/python3.8-torch2.2.1-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.2.1-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.8-torch2.2.1-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.2.1-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch

--- a/src/monobase/requirements/g00018/python3.8-torch2.2.1-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.2.1-cu121.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch

--- a/src/monobase/requirements/g00018/python3.8-torch2.2.2-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.2.2-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.8-torch2.2.2-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.2.2-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch

--- a/src/monobase/requirements/g00018/python3.8-torch2.2.2-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.2.2-cu121.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch

--- a/src/monobase/requirements/g00018/python3.8-torch2.3.0-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.3.0-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.8-torch2.3.0-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.3.0-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch

--- a/src/monobase/requirements/g00018/python3.8-torch2.3.0-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.3.0-cu121.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch

--- a/src/monobase/requirements/g00018/python3.8-torch2.3.1-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.3.1-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.8-torch2.3.1-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.3.1-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch

--- a/src/monobase/requirements/g00018/python3.8-torch2.3.1-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.3.1-cu121.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch

--- a/src/monobase/requirements/g00018/python3.8-torch2.4.0-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.4.0-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.8-torch2.4.0-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.4.0-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch

--- a/src/monobase/requirements/g00018/python3.8-torch2.4.0-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.4.0-cu121.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch

--- a/src/monobase/requirements/g00018/python3.8-torch2.4.0-cu124.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.4.0-cu124.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu124
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch

--- a/src/monobase/requirements/g00018/python3.8-torch2.4.1-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.4.1-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.8-torch2.4.1-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.4.1-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch

--- a/src/monobase/requirements/g00018/python3.8-torch2.4.1-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.4.1-cu121.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch

--- a/src/monobase/requirements/g00018/python3.8-torch2.4.1-cu124.txt
+++ b/src/monobase/requirements/g00018/python3.8-torch2.4.1-cu124.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu124
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch

--- a/src/monobase/requirements/g00018/python3.9-torch2.0.0-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.0.0-cpu.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cpu
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -35,7 +37,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.9-torch2.0.0-cu117.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.0.0-cu117.txt
@@ -12,6 +12,8 @@ charset-normalizer==2.1.1
 cmake==3.25.0
     # via triton
     # from https://download.pytorch.org/whl/cu117
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -49,7 +51,7 @@ nvidia-cuda-nvrtc-cu11==11.8.89
     # from https://pypi.org/simple
 nvidia-cuda-runtime-cu11==11.8.89
     # from https://pypi.org/simple
-nvidia-cudnn-cu11==9.8.0.87
+nvidia-cudnn-cu11==9.9.0.52
     # from https://pypi.org/simple
 nvidia-cufft-cu11==10.9.0.58
     # from https://pypi.org/simple
@@ -68,7 +70,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu117
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.9-torch2.0.0-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.0.0-cu118.txt
@@ -12,6 +12,8 @@ charset-normalizer==2.1.1
 cmake==3.25.0
     # via triton
     # from https://download.pytorch.org/whl/cu118
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -68,7 +70,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.9-torch2.0.1-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.0.1-cpu.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cpu
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -35,7 +37,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.9-torch2.0.1-cu117.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.0.1-cu117.txt
@@ -12,6 +12,8 @@ charset-normalizer==2.1.1
 cmake==3.25.0
     # via triton
     # from https://download.pytorch.org/whl/cu117
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -49,7 +51,7 @@ nvidia-cuda-nvrtc-cu11==11.8.89
     # from https://pypi.org/simple
 nvidia-cuda-runtime-cu11==11.8.89
     # from https://pypi.org/simple
-nvidia-cudnn-cu11==9.8.0.87
+nvidia-cudnn-cu11==9.9.0.52
     # from https://pypi.org/simple
 nvidia-cufft-cu11==10.9.0.58
     # from https://pypi.org/simple
@@ -68,7 +70,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu117
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.9-torch2.0.1-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.0.1-cu118.txt
@@ -12,6 +12,8 @@ charset-normalizer==2.1.1
 cmake==3.25.0
     # via triton
     # from https://download.pytorch.org/whl/cu118
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -68,7 +70,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.9-torch2.1.0-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.1.0-cpu.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cpu
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -38,7 +40,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.9-torch2.1.0-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.1.0-cu118.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cu118
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -65,7 +67,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.9-torch2.1.0-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.1.0-cu121.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cu121
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -71,7 +73,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.9-torch2.1.1-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.1.1-cpu.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cpu
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -38,7 +40,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.9-torch2.1.1-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.1.1-cu118.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cu118
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -65,7 +67,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.9-torch2.1.1-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.1.1-cu121.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cu121
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -71,7 +73,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.9-torch2.1.2-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.1.2-cpu.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cpu
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -38,7 +40,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.9-torch2.1.2-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.1.2-cu118.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cu118
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -65,7 +67,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.9-torch2.1.2-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.1.2-cu121.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cu121
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -71,7 +73,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.9-torch2.2.0-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.2.0-cpu.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cpu
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -38,7 +40,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.9-torch2.2.0-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.2.0-cu118.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cu118
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -76,7 +78,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.9-torch2.2.0-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.2.0-cu121.txt
@@ -9,6 +9,8 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
     # via requests
     # from https://download.pytorch.org/whl/cu121
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -83,7 +85,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 requests==2.28.1
     # via torchvision

--- a/src/monobase/requirements/g00018/python3.9-torch2.2.1-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.2.1-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.9-torch2.2.1-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.2.1-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -67,7 +69,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu118

--- a/src/monobase/requirements/g00018/python3.9-torch2.2.1-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.2.1-cu121.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -74,7 +76,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu121

--- a/src/monobase/requirements/g00018/python3.9-torch2.2.2-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.2.2-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.9-torch2.2.2-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.2.2-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -67,7 +69,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu118

--- a/src/monobase/requirements/g00018/python3.9-torch2.2.2-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.2.2-cu121.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -74,7 +76,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu121

--- a/src/monobase/requirements/g00018/python3.9-torch2.3.0-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.3.0-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.9-torch2.3.0-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.3.0-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -67,7 +69,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu118

--- a/src/monobase/requirements/g00018/python3.9-torch2.3.0-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.3.0-cu121.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -74,7 +76,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu121

--- a/src/monobase/requirements/g00018/python3.9-torch2.3.1-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.3.1-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.9-torch2.3.1-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.3.1-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -67,7 +69,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu118

--- a/src/monobase/requirements/g00018/python3.9-torch2.3.1-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.3.1-cu121.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -74,7 +76,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu121

--- a/src/monobase/requirements/g00018/python3.9-torch2.4.0-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.4.0-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.9-torch2.4.0-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.4.0-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -67,7 +69,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu118

--- a/src/monobase/requirements/g00018/python3.9-torch2.4.0-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.4.0-cu121.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -74,7 +76,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu121

--- a/src/monobase/requirements/g00018/python3.9-torch2.4.0-cu124.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.4.0-cu124.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu124
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -75,7 +77,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu124
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu124

--- a/src/monobase/requirements/g00018/python3.9-torch2.4.1-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.4.1-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.9-torch2.4.1-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.4.1-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -67,7 +69,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu118

--- a/src/monobase/requirements/g00018/python3.9-torch2.4.1-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.4.1-cu121.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -74,7 +76,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu121

--- a/src/monobase/requirements/g00018/python3.9-torch2.4.1-cu124.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.4.1-cu124.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu124
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -75,7 +77,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu124
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu124

--- a/src/monobase/requirements/g00018/python3.9-torch2.5.0-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.5.0-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.9-torch2.5.0-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.5.0-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -67,7 +69,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu118

--- a/src/monobase/requirements/g00018/python3.9-torch2.5.0-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.5.0-cu121.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -74,7 +76,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu121

--- a/src/monobase/requirements/g00018/python3.9-torch2.5.0-cu124.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.5.0-cu124.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu124
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -75,7 +77,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu124
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu124

--- a/src/monobase/requirements/g00018/python3.9-torch2.5.1-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.5.1-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.9-torch2.5.1-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.5.1-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -67,7 +69,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu118

--- a/src/monobase/requirements/g00018/python3.9-torch2.5.1-cu121.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.5.1-cu121.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -74,7 +76,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu121
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu121

--- a/src/monobase/requirements/g00018/python3.9-torch2.5.1-cu124.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.5.1-cu124.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu124
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via
     #   torch
@@ -75,7 +77,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu124
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu124

--- a/src/monobase/requirements/g00018/python3.9-torch2.6.0-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.6.0-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.9-torch2.6.0-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.6.0-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cu118
@@ -65,7 +67,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu118

--- a/src/monobase/requirements/g00018/python3.9-torch2.6.0-cu124.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.6.0-cu124.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu124
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cu124
@@ -76,7 +78,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu124
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu124

--- a/src/monobase/requirements/g00018/python3.9-torch2.6.0-cu126.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.6.0-cu126.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu126
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cu126
@@ -77,7 +79,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu126
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cu126

--- a/src/monobase/requirements/g00018/python3.9-torch2.7.0-cpu.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.7.0-cpu.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cpu
@@ -29,7 +31,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cpu
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # from https://download.pytorch.org/whl/cpu

--- a/src/monobase/requirements/g00018/python3.9-torch2.7.0-cu118.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.7.0-cu118.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cu118
@@ -65,7 +67,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu118
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via triton

--- a/src/monobase/requirements/g00018/python3.9-torch2.7.0-cu126.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.7.0-cu126.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu126
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cu126
@@ -80,7 +82,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu126
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via triton

--- a/src/monobase/requirements/g00018/python3.9-torch2.7.0-cu128.txt
+++ b/src/monobase/requirements/g00018/python3.9-torch2.7.0-cu128.txt
@@ -3,6 +3,8 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 
+cython==3.0.12
+    # from https://pypi.org/simple
 filelock==3.13.1
     # via torch
     # from https://download.pytorch.org/whl/cu128
@@ -80,7 +82,7 @@ packaging==24.1
 pillow==11.0.0
     # via torchvision
     # from https://download.pytorch.org/whl/cu128
-pip==25.1
+pip==25.1.1
     # from https://pypi.org/simple
 setuptools==70.2.0
     # via triton


### PR DESCRIPTION
```
❯ python3 -m monobase.diff 17 18 | cut -f 2- | sort -u
cython  -       3.0.12
nvidia-cudnn-cu11       9.5.0.50        9.9.0.52
pip     25.1    25.1.1
+ python3.10-torch2.6.0-cpu
+ python3.10-torch2.6.0-cu118
+ python3.10-torch2.6.0-cu124
+ python3.10-torch2.6.0-cu126
+ python3.10-torch2.7.0-cpu
+ python3.10-torch2.7.0-cu118
+ python3.10-torch2.7.0-cu126
+ python3.10-torch2.7.0-cu128
+ python3.11-torch2.6.0-cu126
- python3.11-torch2.6.0.dev20240918-cu124
+ python3.11-torch2.7.0-cpu
+ python3.11-torch2.7.0-cu118
+ python3.11-torch2.7.0-cu126
+ python3.11-torch2.7.0-cu128
+ python3.12-torch2.6.0-cu126
- python3.12-torch2.6.0.dev20240918-cu124
+ python3.12-torch2.7.0-cpu
+ python3.12-torch2.7.0-cu118
+ python3.12-torch2.7.0-cu126
+ python3.12-torch2.7.0-cu128
+ python3.13-torch2.6.0-cu126
+ python3.13-torch2.7.0-cpu
+ python3.13-torch2.7.0-cu118
+ python3.13-torch2.7.0-cu126
+ python3.13-torch2.7.0-cu128
+ python3.9-torch2.6.0-cpu
+ python3.9-torch2.6.0-cu118
+ python3.9-torch2.6.0-cu124
+ python3.9-torch2.6.0-cu126
+ python3.9-torch2.7.0-cpu
+ python3.9-torch2.7.0-cu118
+ python3.9-torch2.7.0-cu126
+ python3.9-torch2.7.0-cu128
```