### PR TITLE
Fallback to regular pget when cached prefix

### DIFF
--- a/src/monobase/pget.py
+++ b/src/monobase/pget.py
@@ -126,8 +126,7 @@ def single_pget(url: str, dest: str, extract: bool, force: bool) -> None:
     for prefix in PGET_CACHED_PREFIXES.split(' '):
         # If the URL has a prefix that matches one of the
         # cached prefixes, fall back to pget directly
-        if url.startswith(prefix):
-            assert False
+        assert not url.startswith(prefix)
 
     req = urllib.request.Request(url, method='HEAD')
     resp = urllib.request.urlopen(req)

--- a/src/monobase/pget.py
+++ b/src/monobase/pget.py
@@ -123,7 +123,7 @@ def single_pget(url: str, dest: str, extract: bool, force: bool) -> None:
     if not force:
         assert not os.path.exists(dest)
 
-    for prefix in PGET_CACHED_PREFIXES.split(" "):
+    for prefix in PGET_CACHED_PREFIXES.split(' '):
         # If the URL has a prefix that matches one of the
         # cached prefixes, fall back to pget directly
         if url.startswith(prefix):

--- a/src/monobase/pget.py
+++ b/src/monobase/pget.py
@@ -16,6 +16,7 @@ PGET_BIN = os.environ.get('PGET_BIN', os.path.join(MONOBASE_PREFIX, 'bin/pget-bi
 PGET_METRICS_ENDPOINT = os.environ.get('PGET_METRICS_ENDPOINT')
 FUSE_MOUNT = os.environ.get('FUSE_MOUNT', '/srv/r8/fuse-rpc')
 PROC_FILE = os.path.join(FUSE_MOUNT, 'proc', 'pget')
+PGET_CACHED_PREFIXES = os.environ.get('PGET_CACHE_URI_PREFIX', '')
 
 HF_HOSTS = {
     'cdn-lfs-us-1.hf.co',
@@ -121,6 +122,12 @@ def multi_pget(manifest: str, force: bool) -> None:
 def single_pget(url: str, dest: str, extract: bool, force: bool) -> None:
     if not force:
         assert not os.path.exists(dest)
+
+    for prefix in PGET_CACHED_PREFIXES.split(" "):
+        # If the URL has a prefix that matches one of the
+        # cached prefixes, fall back to pget directly
+        if url.startswith(prefix):
+            assert False
 
     req = urllib.request.Request(url, method='HEAD')
     resp = urllib.request.urlopen(req)


### PR DESCRIPTION
### Summary

When we find a prefix that would be cached through Hermes, use it instead of FUSE. In general because of all the layers of indirection, we see slowness in FUSE that we think would be faster through Hermes instead, plus cuts down on some complexity