### PR TITLE
Support maintaining top k files on disk

### DIFF
--- a/src/monobase/pget.py
+++ b/src/monobase/pget.py
@@ -129,6 +129,9 @@ def single_pget(url: str, dest: str, extract: bool, force: bool) -> None:
     fpath = os.path.join(KNOWN_WEIGHTS_DIR, m.hexdigest())
     if os.path.exists(fpath):
         if extract:
+            # rm -rf if -xf
+            if force:
+                os.rmdir(fpath)
             # dest is a directory
             os.makedirs(dest, exist_ok=True)
             # pget does not support zip

--- a/src/monobase/pget.py
+++ b/src/monobase/pget.py
@@ -136,6 +136,8 @@ def single_pget(url: str, dest: str, extract: bool, force: bool) -> None:
             cmd = ['tar', '-xf', fpath, '-C', dest]
             subprocess.run(cmd, check=True)
         else:
+            if force and os.path.exists(dest):
+                os.unlink(dest)
             os.symlink(fpath, dest)
 
     for prefix in PGET_CACHED_PREFIXES.split(' '):

--- a/src/monobase/pget.py
+++ b/src/monobase/pget.py
@@ -17,6 +17,7 @@ PGET_METRICS_ENDPOINT = os.environ.get('PGET_METRICS_ENDPOINT')
 FUSE_MOUNT = os.environ.get('FUSE_MOUNT', '/srv/r8/fuse-rpc')
 PROC_FILE = os.path.join(FUSE_MOUNT, 'proc', 'pget')
 PGET_CACHED_PREFIXES = os.environ.get('PGET_CACHE_URI_PREFIX', '')
+KNOWN_WEIGHTS_PREFIX = os.environ.get('KNOWN_WEIGHTS_PREFIX', '')
 
 HF_HOSTS = {
     'cdn-lfs-us-1.hf.co',
@@ -122,6 +123,20 @@ def multi_pget(manifest: str, force: bool) -> None:
 def single_pget(url: str, dest: str, extract: bool, force: bool) -> None:
     if not force:
         assert not os.path.exists(dest)
+
+    m = hashlib.sha256()
+    m.update(url.encode()) # default encoding of utf-8
+    fpath = os.path.join(KNOWN_WEIGHTS_PREFIX, m.hexdigest())
+    if os.path.exists(fpath):
+        if extract:
+            # dest is a directory
+            os.makedirs(dest, exist_ok=True)
+            # pget does not support zip
+            # tar will overwrite existing files
+            cmd = ['tar', '-xf', fpath, '-C', dest]
+            subprocess.run(cmd, check=True)
+        else:
+            os.symlink(fpath, dest)
 
     for prefix in PGET_CACHED_PREFIXES.split(' '):
         # If the URL has a prefix that matches one of the

--- a/src/monobase/pget.py
+++ b/src/monobase/pget.py
@@ -17,7 +17,7 @@ PGET_METRICS_ENDPOINT = os.environ.get('PGET_METRICS_ENDPOINT')
 FUSE_MOUNT = os.environ.get('FUSE_MOUNT', '/srv/r8/fuse-rpc')
 PROC_FILE = os.path.join(FUSE_MOUNT, 'proc', 'pget')
 PGET_CACHED_PREFIXES = os.environ.get('PGET_CACHE_URI_PREFIX', '')
-KNOWN_WEIGHTS_DIR = os.environ.get('KNOWN_WEIGHTS_DIR', '')
+PGET_KNOWN_WEIGHTS_DIR = os.environ.get('PGET_KNOWN_WEIGHTS_DIR', '')
 
 HF_HOSTS = {
     'cdn-lfs-us-1.hf.co',
@@ -126,12 +126,9 @@ def single_pget(url: str, dest: str, extract: bool, force: bool) -> None:
 
     m = hashlib.sha256()
     m.update(url.encode())  # default encoding of utf-8
-    fpath = os.path.join(KNOWN_WEIGHTS_DIR, m.hexdigest())
+    fpath = os.path.join(PGET_KNOWN_WEIGHTS_DIR, m.hexdigest())
     if os.path.exists(fpath):
         if extract:
-            # rm -rf if -xf
-            if force:
-                os.rmdir(fpath)
             # dest is a directory
             os.makedirs(dest, exist_ok=True)
             # pget does not support zip

--- a/src/monobase/pget.py
+++ b/src/monobase/pget.py
@@ -125,7 +125,7 @@ def single_pget(url: str, dest: str, extract: bool, force: bool) -> None:
         assert not os.path.exists(dest)
 
     m = hashlib.sha256()
-    m.update(url.encode()) # default encoding of utf-8
+    m.update(url.encode())  # default encoding of utf-8
     fpath = os.path.join(KNOWN_WEIGHTS_PREFIX, m.hexdigest())
     if os.path.exists(fpath):
         if extract:

--- a/src/monobase/pget.py
+++ b/src/monobase/pget.py
@@ -17,7 +17,7 @@ PGET_METRICS_ENDPOINT = os.environ.get('PGET_METRICS_ENDPOINT')
 FUSE_MOUNT = os.environ.get('FUSE_MOUNT', '/srv/r8/fuse-rpc')
 PROC_FILE = os.path.join(FUSE_MOUNT, 'proc', 'pget')
 PGET_CACHED_PREFIXES = os.environ.get('PGET_CACHE_URI_PREFIX', '')
-KNOWN_WEIGHTS_PREFIX = os.environ.get('KNOWN_WEIGHTS_PREFIX', '')
+KNOWN_WEIGHTS_DIR = os.environ.get('KNOWN_WEIGHTS_DIR', '')
 
 HF_HOSTS = {
     'cdn-lfs-us-1.hf.co',
@@ -126,7 +126,7 @@ def single_pget(url: str, dest: str, extract: bool, force: bool) -> None:
 
     m = hashlib.sha256()
     m.update(url.encode())  # default encoding of utf-8
-    fpath = os.path.join(KNOWN_WEIGHTS_PREFIX, m.hexdigest())
+    fpath = os.path.join(KNOWN_WEIGHTS_DIR, m.hexdigest())
     if os.path.exists(fpath):
         if extract:
             # dest is a directory

--- a/src/monobase/refresh_files.py
+++ b/src/monobase/refresh_files.py
@@ -15,7 +15,7 @@ from http import HTTPStatus
 
 MONOBASE_PREFIX = os.environ.get('MONOBASE_PREFIX', '/srv/r8/monobase')
 PGET_BIN = os.environ.get('PGET_BIN', os.path.join(MONOBASE_PREFIX, 'bin/pget-bin'))
-KNOWN_WEIGHTS_DIR = os.environ.get('KNOWN_WEIGHTS_DIR', '')
+PGET_KNOWN_WEIGHTS_DIR = os.environ.get('PGET_KNOWN_WEIGHTS_DIR', '')
 
 parser = argparse.ArgumentParser('refresh_files')
 parser.add_argument('-q', '--query-url', type=str, required=True)
@@ -119,9 +119,9 @@ def main(query_url, query_id, upstream, auth_token, max_size) -> None:
         total_size += size
 
     # Delete files that should no longer be here so we keep the directory clean
-    for file in os.listdir(KNOWN_WEIGHTS_DIR):
+    for file in os.listdir(PGET_KNOWN_WEIGHTS_DIR):
         if file not in file_set:
-            os.remove(os.path.join(KNOWN_WEIGHTS_DIR, file))
+            os.remove(os.path.join(PGET_KNOWN_WEIGHTS_DIR, file))
 
     p = find_pget_exe()
     # pget each of the files into the new directory
@@ -133,14 +133,14 @@ def main(query_url, query_id, upstream, auth_token, max_size) -> None:
                 file = re.sub(r'https?://', '', file)
             file = f'{upstream}/{file}'
         try:
-            # Download to tmp directory, then move into KNOWN_WEIGHTS_DIR directory
+            # Download to tmp directory, then move into PGET_KNOWN_WEIGHTS_DIR directory
             subprocess.run(
-                [p, file, os.path.join(KNOWN_WEIGHTS_DIR, 'tmp', h.hexdigest())],
+                [p, file, os.path.join(PGET_KNOWN_WEIGHTS_DIR, 'tmp', h.hexdigest())],
                 check=True,
             )
             shutil.move(
-                os.path.join(KNOWN_WEIGHTS_DIR, 'tmp', h.hexdigest()),
-                os.path.join(KNOWN_WEIGHTS_DIR, h.hexdigest()),
+                os.path.join(PGET_KNOWN_WEIGHTS_DIR, 'tmp', h.hexdigest()),
+                os.path.join(PGET_KNOWN_WEIGHTS_DIR, h.hexdigest()),
             )
         except Exception as e:
             print(f'Error downloading {file}: {e}')

--- a/src/monobase/refresh_files.py
+++ b/src/monobase/refresh_files.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+
+import argparse
+from datetime import datetime
+from http import HTTPStatus
+import hashlib
+import os
+import re
+import requests
+import shutil
+import subprocess
+import sys
+import time
+
+parser = argparse.ArgumentParser('refresh_files')
+parser.add_argument('-f', '--file-stats-url', type=str)
+parser.add_argument('-u', '--upstream-url', type=str)
+parser.add_argument('-p', '--parent-dir', type=str)
+
+KNOWN_WEIGHTS_DIR_ENV_VAR = 'KNOWN_WEIGHTS_DIR'
+
+def find_pget_exe() -> str:
+    # Look for real executable in PATH
+    for p in os.environ['PATH'].split(os.pathsep):
+        f = shutil.which('pget', path=p)
+        if f is not None and f != __file__:
+            return f
+    print('Cannot find pget executable', file=sys.stderr)
+    sys.exit(1)
+
+def main(url, upstream, parent_dir) -> None:
+    if not url:
+        print("Misconfigured files URL, exiting")
+        sys.exit(1)
+    resp = requests.get(url)
+    if resp.status_code != HTTPStatus.OK:
+        print(f"Failed request to {url}: {resp.text}; exiting")
+        sys.exit(1)
+
+    # The expectation for response from the file-stats-url is that
+    # it is a GET request that returns a list of files, like
+    # {
+    #   "files": [
+    #     "URL1",
+    #     "URL2",
+    #     "...",
+    #   ]
+    # }
+    body = resp.json()
+    if "files" not in body:
+        print(f"Malformatted response: {body}; exiting")
+        sys.exit(1)
+
+    old_dir = os.environ.get(KNOWN_WEIGHTS_DIR_ENV_VAR)
+
+    # Create a new directory to be the known_files_directory
+    now = datetime.now()
+    m = hashlib.sha256(now.strftime("%Y-%m-%d-%H:%M:%S"))
+    new_dir = os.path.join(parent_dir, m.hexdigest())
+    os.makedirs(new_dir)
+    p = find_pget_exe()
+    # pget each of the files into the new directory
+    for file in body["files"]:
+        h = hashlib.sha256(file)
+        old_path = os.path.join(old_dir, h.hexdigest())
+        new_path = os.path.join(new_dir, h.hexdigest())
+        # Copy instead of pget if the old path already exists
+        if os.path.exists(old_path):
+            shutil.copy(old_path, new_path)
+        else:
+            # If we have an upstream, make the URL <upstream>/<file> but strip http(s)://
+            # from the <file> URL
+            if upstream:
+                if file.startswith('http'):
+                    file = re.sub(r'https?:\\', '', file)
+                file = f"{upstream}/{file}"
+            subprocess.run([p, file, new_path])
+    
+    # Switch the old env var
+    os.environ[KNOWN_WEIGHTS_DIR_ENV_VAR] = new_dir
+
+    # Remove old cache dir after 10 minutes to make sure nothing is reading from
+    # those files anymore
+    if old_dir:
+        time.sleep(600)
+        os.rmdir(old_dir)
+
+if __name__ == '__main__':
+    args = parser.parse_args()
+    main(args.file_stats_url, args.upstream_url, args.parent_dir)

--- a/src/monobase/refresh_files.py
+++ b/src/monobase/refresh_files.py
@@ -17,7 +17,7 @@ PGET_BIN = os.environ.get('PGET_BIN', os.path.join(MONOBASE_PREFIX, 'bin/pget-bi
 KNOWN_WEIGHTS_DIR = os.environ.get('KNOWN_WEIGHTS_DIR', '')
 
 parser = argparse.ArgumentParser('refresh_files')
-parser.add_argument('-f', '--file-stats-url', type=str)
+parser.add_argument('-q', '--query-url', type=str)
 parser.add_argument('-u', '--upstream-url', type=str)
 parser.add_argument('-a', '--auth-token', type=str)
 
@@ -109,4 +109,4 @@ def main(url, upstream, auth_token) -> None:
 
 if __name__ == '__main__':
     args = parser.parse_args()
-    main(args.file_stats_url, args.upstream_url, args.auth_token)
+    main(args.query_url, args.upstream_url, args.auth_token)

--- a/src/monobase/refresh_files.py
+++ b/src/monobase/refresh_files.py
@@ -74,12 +74,12 @@ def main(url, upstream) -> None:
         # from the <file> URL
         if upstream:
             if file.startswith('http'):
-                file = re.sub(r'https?:\\', '', file)
+                file = re.sub(r'https?://', '', file)
             file = f'{upstream}/{file}'
         try:
-            subprocess.run([p, file, os.path.join('/tmp', h.hexdigest())])
+            subprocess.run([p, file, os.path.join(KNOWN_WEIGHTS_DIR, 'tmp', h.hexdigest())], check=True)
             shutil.move(
-                os.path.join('/tmp', h.hexdigest()),
+                os.path.join(KNOWN_WEIGHTS_DIR, 'tmp', h.hexdigest()),
                 os.path.join(KNOWN_WEIGHTS_DIR, h.hexdigest()),
             )
         except Exception as e:

--- a/src/monobase/refresh_files.py
+++ b/src/monobase/refresh_files.py
@@ -65,9 +65,11 @@ def main(url, upstream) -> None:
         sys.exit(1)
 
     p = find_pget_exe()
+    file_set = set([])
     # pget each of the files into the new directory
     for file in body['files']:
         h = hashlib.sha256(file.encode())
+        file_set.add(h.hexdigest())
         # If we have an upstream, make the URL <upstream>/<file> but strip http(s)://
         # from the <file> URL
         if upstream:
@@ -83,6 +85,10 @@ def main(url, upstream) -> None:
         except Exception as e:
             print(f'Error downloading {file}: {e}')
             # Continue on anyways to get the rest of the files
+
+    for file in os.listdir(KNOWN_WEIGHTS_DIR):
+        if file not in file_set:
+            os.remove(os.path.join(KNOWN_WEIGHTS_DIR, file))
 
 
 if __name__ == '__main__':

--- a/src/monobase/refresh_files.py
+++ b/src/monobase/refresh_files.py
@@ -49,12 +49,14 @@ def main(url, upstream, auth_token, max_size) -> None:
         create_resp = urllib.request.urlopen(create_req)
 
         create_body = json.loads(create_resp.read().decode())
-        if "id" not in create_body:
-            print(f"Malformatted response from create endpoint: {create_body}; exiting")
+        if 'id' not in create_body:
+            print(f'Malformatted response from create endpoint: {create_body}; exiting')
             sys.exit(1)
 
         req = urllib.request.Request(
-            urllib.parse.urljoin(url, create_body["id"]), method='GET', headers={'X-Honeycomb-Team': auth_token}
+            urllib.parse.urljoin(url, create_body['id']),
+            method='GET',
+            headers={'X-Honeycomb-Team': auth_token},
         )
         resp = urllib.request.urlopen(req)
     except urllib.error.HTTPError as e:
@@ -100,10 +102,10 @@ def main(url, upstream, auth_token, max_size) -> None:
         file_set.add(h.hexdigest())
 
         # Check we won't violate the total size by downloading this file
-        if "cache.response.object_size" not in data:
+        if 'cache.response.object_size' not in data:
             print(f'Malformatted result: {result}; continuing')
             continue
-        size = data["cache.response.object_size"]
+        size = data['cache.response.object_size']
         if (total_size + size) > max_size:
             print(f'Downloading file would be violate size limit, skipping file {file}')
             continue

--- a/src/monobase/refresh_files.py
+++ b/src/monobase/refresh_files.py
@@ -2,26 +2,29 @@
 
 import argparse
 import hashlib
+import json
 import os
 import re
 import shutil
 import subprocess
 import sys
-import time
-from datetime import datetime
+import urllib
+import urllib.request
 from http import HTTPStatus
 
-import requests
+MONOBASE_PREFIX = os.environ.get('MONOBASE_PREFIX', '/srv/r8/monobase')
+PGET_BIN = os.environ.get('PGET_BIN', os.path.join(MONOBASE_PREFIX, 'bin/pget-bin'))
+KNOWN_WEIGHTS_DIR = os.environ.get('KNOWN_WEIGHTS_DIR', '')
 
 parser = argparse.ArgumentParser('refresh_files')
 parser.add_argument('-f', '--file-stats-url', type=str)
 parser.add_argument('-u', '--upstream-url', type=str)
-parser.add_argument('-p', '--parent-dir', type=str)
-
-KNOWN_WEIGHTS_DIR_ENV_VAR = 'KNOWN_WEIGHTS_DIR'
 
 
 def find_pget_exe() -> str:
+    # PGET_BIN is executable
+    if os.path.isfile(PGET_BIN) and os.access(PGET_BIN, os.X_OK):
+        return PGET_BIN
     # Look for real executable in PATH
     for p in os.environ['PATH'].split(os.pathsep):
         f = shutil.which('pget', path=p)
@@ -31,13 +34,20 @@ def find_pget_exe() -> str:
     sys.exit(1)
 
 
-def main(url, upstream, parent_dir) -> None:
+def main(url, upstream) -> None:
     if not url:
         print('Misconfigured files URL, exiting')
         sys.exit(1)
-    resp = requests.get(url)
-    if resp.status_code != HTTPStatus.OK:
-        print(f'Failed request to {url}: {resp.text}; exiting')
+
+    try:
+        req = urllib.request.Request(url, method='GET')
+        resp = urllib.request.urlopen(req)
+    except urllib.error.HTTPError as e:
+        print(f'Failed request to {url}: {e.read().decode()}; exiting')
+        sys.exit(1)
+
+    if resp.status != HTTPStatus.OK:
+        print(f'Failed request to {url}: {resp.read().decode()}; exiting')
         sys.exit(1)
 
     # The expectation for response from the file-stats-url is that
@@ -49,46 +59,32 @@ def main(url, upstream, parent_dir) -> None:
     #     "...",
     #   ]
     # }
-    body = resp.json()
+    body = json.loads(resp.read().decode())
     if 'files' not in body:
         print(f'Malformatted response: {body}; exiting')
         sys.exit(1)
 
-    old_dir = os.environ.get(KNOWN_WEIGHTS_DIR_ENV_VAR, '')
-
-    # Create a new directory to be the known_files_directory
-    now = datetime.now()
-    m = hashlib.sha256(now.strftime('%Y-%m-%d-%H:%M:%S').encode())
-    new_dir = os.path.join(parent_dir, m.hexdigest())
-    os.makedirs(new_dir)
     p = find_pget_exe()
     # pget each of the files into the new directory
     for file in body['files']:
         h = hashlib.sha256(file.encode())
-        old_path = os.path.join(old_dir, h.hexdigest())
-        new_path = os.path.join(new_dir, h.hexdigest())
-        # Copy instead of pget if the old path already exists
-        if os.path.exists(old_path):
-            shutil.copy(old_path, new_path)
-        else:
-            # If we have an upstream, make the URL <upstream>/<file> but strip http(s)://
-            # from the <file> URL
-            if upstream:
-                if file.startswith('http'):
-                    file = re.sub(r'https?:\\', '', file)
-                file = f'{upstream}/{file}'
-            subprocess.run([p, file, new_path])
-
-    # Switch the old env var
-    os.environ[KNOWN_WEIGHTS_DIR_ENV_VAR] = new_dir
-
-    # Remove old cache dir after 10 minutes to make sure nothing is reading from
-    # those files anymore
-    if old_dir:
-        time.sleep(600)
-        os.rmdir(old_dir)
+        # If we have an upstream, make the URL <upstream>/<file> but strip http(s)://
+        # from the <file> URL
+        if upstream:
+            if file.startswith('http'):
+                file = re.sub(r'https?:\\', '', file)
+            file = f'{upstream}/{file}'
+        try:
+            subprocess.run([p, file, os.path.join('/tmp', h.hexdigest())])
+            shutil.move(
+                os.path.join('/tmp', h.hexdigest()),
+                os.path.join(KNOWN_WEIGHTS_DIR, h.hexdigest()),
+            )
+        except Exception as e:
+            print(f'Error downloading {file}: {e}')
+            # Continue on anyways to get the rest of the files
 
 
 if __name__ == '__main__':
     args = parser.parse_args()
-    main(args.file_stats_url, args.upstream_url, args.parent_dir)
+    main(args.file_stats_url, args.upstream_url)


### PR DESCRIPTION
### Summary

One of our experiments will be taking the top 1-2 TB of files and hosting them on disk. Rather than downloading them every time, we'll simply symlink them in if they are on disk. This idea should gain us pretty significant speedup as a whole since a significant proportion of our traffic comes from like 15-20 models.