### PR TITLE
Move FUSE check

### DIFF
--- a/src/monobase/pget.py
+++ b/src/monobase/pget.py
@@ -139,6 +139,7 @@ def single_pget(url: str, dest: str, extract: bool, force: bool) -> None:
             if force and os.path.exists(dest):
                 os.unlink(dest)
             os.symlink(fpath, dest)
+        return
 
     for prefix in PGET_CACHED_PREFIXES.split(' '):
         # If the URL has a prefix that matches one of the

--- a/src/monobase/pget.py
+++ b/src/monobase/pget.py
@@ -117,7 +117,12 @@ def send_pget_metrics(url: str, size: int) -> None:
 def multi_pget(manifest: str, force: bool) -> None:
     urls = parse_manifest(manifest)
     for dest, url in urls.items():
-        single_pget(url, dest, extract=False, force=force)
+        try:
+            single_pget(url, dest, extract=False, force=force)
+        except Exception:
+            # Fall back to regular pget, just for this file
+            p = find_pget_exe()
+            subprocess.run([p, url, dest])
 
 
 def single_pget(url: str, dest: str, extract: bool, force: bool) -> None:

--- a/src/monobase/pget.py
+++ b/src/monobase/pget.py
@@ -145,6 +145,9 @@ def single_pget(url: str, dest: str, extract: bool, force: bool) -> None:
         # cached prefixes, fall back to pget directly
         assert not url.startswith(prefix)
 
+    # Fall back if no FUSE
+    assert os.path.exists(PROC_FILE)
+
     req = urllib.request.Request(url, method='HEAD')
     resp = urllib.request.urlopen(req)
 
@@ -184,15 +187,7 @@ def single_pget(url: str, dest: str, extract: bool, force: bool) -> None:
 
 
 def smart_pget() -> None:
-    # Fall back if no FUSE
-    assert os.path.exists(PROC_FILE)
-
     args, vargs = parser.parse_known_args()
-
-    # FUSE server is not configured to use storage cache
-    # So these tar files are downloaded from CDN at lower speed
-    # That plus tar files are not lazily loadable defeats the point of having them in FUSE cache
-    assert not args.extract
 
     # Supported:
     # pget [flags] <URL> <dest>


### PR DESCRIPTION
### Summary

Previously, we instantly defaulted to regular pget if FUSE didn't exist. Now, we should check if the file is in local cache, then check if FUSE exists